### PR TITLE
Update README to fix incorrect Go import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export const output = random.stdout;
 package main
 
 import (
-	"github.com/pulumi/pulumi-command/sdk/v3/go/command/local"
+	"github.com/pulumi/pulumi-command/sdk/go/command/local"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -38,7 +38,7 @@ export const output = random.stdout;
 package main
 
 import (
-	"github.com/pulumi/pulumi-command/sdk/v3/go/command/local"
+	"github.com/pulumi/pulumi-command/sdk/go/command/local"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
The Go example had an import at `v3/go/` instead of just `go/`