### PR TITLE
Add Godoc badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pulumi Command Provider (preview)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/pulumi/pulumi-command.svg)](https://pkg.go.dev/github.com/pulumi/pulumi-command)
+
 The Pulumi Command Provider enables you to execute commands and scripts either locally or remotely as part of the Pulumi resource model.  Resources in the command package support running scripts on `create` and `destroy` operations, supporting stateful local and remote command execution.
 
 There are many scenarios where the Command package can be useful:


### PR DESCRIPTION
This PR closes https://github.com/pulumi/pulumi-command/issues/70

I wanted to add badges for PyPi, NPM, etc but apparently, they don't offer a badge generator tool like Go does.