### PR TITLE
Prevent panic if dir is nil

### DIFF
--- a/provider/pkg/provider/command.go
+++ b/provider/pkg/provider/command.go
@@ -79,7 +79,6 @@ func (c *command) RunCreate(ctx context.Context, host *provider.HostClient, urn 
 	return id, err
 }
 
-//
 func (c *command) RunUpdate(ctx context.Context, host *provider.HostClient, urn resource.URN) (string, error) {
 	if c.Update != nil {
 		stdout, stderr, id, err := c.run(ctx, *c.Update, host, urn)
@@ -131,6 +130,14 @@ func (c *commandContext) run(ctx context.Context, command string, host *provider
 	cmd.Stdout = stdoutw
 	cmd.Stderr = stderrw
 	if c.Dir != nil {
+		// Check if exists and is a directory.
+		stat, err := os.Stat(*c.Dir)
+		if err != nil {
+			return "", "", "", fmt.Errorf("error looking up directory: %q", err)
+		}
+		if !stat.IsDir() {
+			return "", "", "", fmt.Errorf("%s is not a directory", *c.Dir)
+		}
 		cmd.Dir = *c.Dir
 	} else {
 		cmd.Dir, err = os.Getwd()


### PR DESCRIPTION
Resolves #93, Checks if provided dir string exists and is a directory, with a more helpful error message for both cases:

<img width="865" alt="image" src="https://user-images.githubusercontent.com/41454626/189575812-574de8aa-2a39-4877-ae45-7d7285b81dd8.png">

<img width="737" alt="image" src="https://user-images.githubusercontent.com/41454626/189575358-f8b5c59b-15af-40f6-bb08-237d1c7f573b.png">
