### PR TITLE
Allow `delete` and `update` operations to access `stdout` via `PULUMI_COMMAND_STDOUT`.

### DIFF
--- a/examples/delete-from-stdout/Pulumi.yaml
+++ b/examples/delete-from-stdout/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: command-delete-from-stdout
+runtime: nodejs
+description: A simple command example

--- a/examples/delete-from-stdout/index.ts
+++ b/examples/delete-from-stdout/index.ts
@@ -1,0 +1,8 @@
+import { local } from "@pulumi/command";
+
+const mktemp = new local.Command('mktemp', {
+    create: 'mktemp',
+    delete: 'rm $PULUMI_COMMAND_STDOUT'
+})
+
+export const output = mktemp.stdout;

--- a/examples/delete-from-stdout/package.json
+++ b/examples/delete-from-stdout/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "command-delete-from-stdout",
+    "version": "0.1.0",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "^4.2.0"
+    }
+}

--- a/examples/delete-from-stdout/tsconfig.json
+++ b/examples/delete-from-stdout/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -6,6 +6,7 @@ package examples
 
 import (
 	"encoding/base64"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,6 +27,20 @@ func TestRandom(t *testing.T) {
 				out, ok := stack.Outputs["output"].(string)
 				assert.True(t, ok)
 				assert.Len(t, out, 32)
+			},
+		})
+	integration.ProgramTest(t, &test)
+}
+
+func TestDeleteFromStdout(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "delete-from-stdout"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				out, ok := stack.Outputs["output"].(string)
+				assert.True(t, ok)
+				_, err := os.Stat(out)
+				assert.NoError(t, err)
 			},
 		})
 	integration.ProgramTest(t, &test)

--- a/provider/cmd/pulumi-resource-command/schema.json
+++ b/provider/cmd/pulumi-resource-command/schema.json
@@ -190,7 +190,7 @@
                     "type": "string"
                 },
                 "delete": {
-                    "description": "The command to run on delete.",
+                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
                     "type": "string"
                 },
                 "dir": {
@@ -224,7 +224,7 @@
                     "type": "array"
                 },
                 "update": {
-                    "description": "The command to run on update, if empty, create will run again.",
+                    "description": "The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
                     "type": "string"
                 }
             },
@@ -259,7 +259,7 @@
                     "type": "string"
                 },
                 "delete": {
-                    "description": "The command to run on delete.",
+                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
                     "type": "string"
                 },
                 "dir": {
@@ -301,7 +301,7 @@
                     "type": "array"
                 },
                 "update": {
-                    "description": "The command to run on update, if empty, create will run again.",
+                    "description": "The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
                     "type": "string"
                 }
             },

--- a/provider/cmd/pulumi-resource-command/schema.json
+++ b/provider/cmd/pulumi-resource-command/schema.json
@@ -190,7 +190,7 @@
                     "type": "string"
                 },
                 "delete": {
-                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
+                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT\nand PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the\nCommand resource from previous create or update steps.",
                     "type": "string"
                 },
                 "dir": {
@@ -224,7 +224,7 @@
                     "type": "array"
                 },
                 "update": {
-                    "description": "The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
+                    "description": "The command to run on update, if empty, create will \nrun again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR \nare set to the stdout and stderr properties of the Command resource from previous \ncreate or update steps.",
                     "type": "string"
                 }
             },
@@ -259,7 +259,7 @@
                     "type": "string"
                 },
                 "delete": {
-                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
+                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT\nand PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the\nCommand resource from previous create or update steps.",
                     "type": "string"
                 },
                 "dir": {
@@ -301,7 +301,7 @@
                     "type": "array"
                 },
                 "update": {
-                    "description": "The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.",
+                    "description": "The command to run on update, if empty, create will \nrun again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR \nare set to the stdout and stderr properties of the Command resource from previous \ncreate or update steps.",
                     "type": "string"
                 }
             },
@@ -323,7 +323,7 @@
                     "type": "string"
                 },
                 "delete": {
-                    "description": "The command to run on delete.",
+                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT\nand PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the\nCommand resource from previous create or update steps.",
                     "type": "string"
                 },
                 "environment": {
@@ -346,7 +346,7 @@
                     "type": "array"
                 },
                 "update": {
-                    "description": "The command to run on update, if empty, create will run again.",
+                    "description": "The command to run on update, if empty, create will \nrun again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR \nare set to the stdout and stderr properties of the Command resource from previous \ncreate or update steps.",
                     "type": "string"
                 }
             },
@@ -361,7 +361,7 @@
                     "type": "string"
                 },
                 "delete": {
-                    "description": "The command to run on delete.",
+                    "description": "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT\nand PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the\nCommand resource from previous create or update steps.",
                     "type": "string"
                 },
                 "environment": {
@@ -392,7 +392,7 @@
                     "type": "array"
                 },
                 "update": {
-                    "description": "The command to run on update, if empty, create will run again.",
+                    "description": "The command to run on update, if empty, create will \nrun again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR \nare set to the stdout and stderr properties of the Command resource from previous \ncreate or update steps.",
                     "type": "string"
                 }
             },

--- a/provider/pkg/provider/local/command.go
+++ b/provider/pkg/provider/local/command.go
@@ -58,12 +58,13 @@ func (c *CommandInputs) Annotate(a infer.Annotator) {
 	c.BaseInputs.Annotate(a)
 	a.Describe(&c.Triggers, "Trigger replacements on changes to this input.")
 	a.Describe(&c.Create, "The command to run on create.")
-	a.Describe(&c.Delete, "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT "+
-		"and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from "+
-		"previous create or update steps.")
-	a.Describe(&c.Update, "The command to run on update, if empty, create will run again. The environment "+
-		"variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties "+
-		"of the Command resource from previous create or update steps.")
+	a.Describe(&c.Delete, `The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+Command resource from previous create or update steps.`)
+	a.Describe(&c.Update, `The command to run on update, if empty, create will 
+run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+are set to the stdout and stderr properties of the Command resource from previous 
+create or update steps.`)
 }
 
 // These are the outputs (or properties) of a Command resource.

--- a/provider/pkg/provider/local/command.go
+++ b/provider/pkg/provider/local/command.go
@@ -58,8 +58,12 @@ func (c *CommandInputs) Annotate(a infer.Annotator) {
 	c.BaseInputs.Annotate(a)
 	a.Describe(&c.Triggers, "Trigger replacements on changes to this input.")
 	a.Describe(&c.Create, "The command to run on create.")
-	a.Describe(&c.Delete, "The command to run on delete.")
-	a.Describe(&c.Update, "The command to run on update, if empty, create will run again.")
+	a.Describe(&c.Delete, "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT "+
+		"and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from "+
+		"previous create or update steps.")
+	a.Describe(&c.Update, "The command to run on update, if empty, create will run again. The environment "+
+		"variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties "+
+		"of the Command resource from previous create or update steps.")
 }
 
 // These are the outputs (or properties) of a Command resource.

--- a/provider/pkg/provider/local/commandOutputs.go
+++ b/provider/pkg/provider/local/commandOutputs.go
@@ -33,6 +33,9 @@ import (
 	"github.com/pulumi/pulumi-command/provider/pkg/provider/util"
 )
 
+const PULUMI_COMMAND_STDOUT = "PULUMI_COMMAND_STDOUT"
+const PULUMI_COMMAND_STDERR = "PULUMI_COMMAND_STDERR"
+
 func (c *CommandOutputs) run(ctx p.Context, command string) (string, string, error) {
 	var args []string
 	if c.Interpreter != nil && len(*c.Interpreter) > 0 {
@@ -71,6 +74,12 @@ func (c *CommandOutputs) run(ctx p.Context, command string) (string, string, err
 		for k, v := range *c.Environment {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 		}
+	}
+	if c.Stdout != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PULUMI_COMMAND_STDOUT, c.Stdout))
+	}
+	if c.Stderr != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PULUMI_COMMAND_STDERR, c.Stderr))
 	}
 
 	if c.Stdin != nil && len(*c.Stdin) > 0 {

--- a/provider/pkg/provider/local/commandOutputs.go
+++ b/provider/pkg/provider/local/commandOutputs.go
@@ -33,9 +33,6 @@ import (
 	"github.com/pulumi/pulumi-command/provider/pkg/provider/util"
 )
 
-const PULUMI_COMMAND_STDOUT = "PULUMI_COMMAND_STDOUT"
-const PULUMI_COMMAND_STDERR = "PULUMI_COMMAND_STDERR"
-
 func (c *CommandOutputs) run(ctx p.Context, command string) (string, string, error) {
 	var args []string
 	if c.Interpreter != nil && len(*c.Interpreter) > 0 {
@@ -76,10 +73,10 @@ func (c *CommandOutputs) run(ctx p.Context, command string) (string, string, err
 		}
 	}
 	if c.Stdout != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PULUMI_COMMAND_STDOUT, c.Stdout))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", util.PULUMI_COMMAND_STDOUT, c.Stdout))
 	}
 	if c.Stderr != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", PULUMI_COMMAND_STDERR, c.Stderr))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", util.PULUMI_COMMAND_STDERR, c.Stderr))
 	}
 
 	if c.Stdin != nil && len(*c.Stdin) > 0 {

--- a/provider/pkg/provider/remote/command.go
+++ b/provider/pkg/provider/remote/command.go
@@ -50,8 +50,13 @@ func (c *CommandInputs) Annotate(a infer.Annotator) {
 	a.Describe(&c.Environment, "Additional environment variables available to the command's process.")
 	a.Describe(&c.Triggers, "Trigger replacements on changes to this input.")
 	a.Describe(&c.Create, "The command to run on create.")
-	a.Describe(&c.Delete, "The command to run on delete.")
-	a.Describe(&c.Update, "The command to run on update, if empty, create will run again.")
+	a.Describe(&c.Delete, `The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+Command resource from previous create or update steps.`)
+	a.Describe(&c.Update, `The command to run on update, if empty, create will 
+run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+are set to the stdout and stderr properties of the Command resource from previous 
+create or update steps.`)
 	a.Describe(&c.Stdin, "Pass a string to the command's process as standard in")
 }
 

--- a/provider/pkg/provider/remote/commandOutputs.go
+++ b/provider/pkg/provider/remote/commandOutputs.go
@@ -48,6 +48,12 @@ func (c *CommandOutputs) run(ctx p.Context, cmd string) (string, string, error) 
 			session.Setenv(k, v)
 		}
 	}
+	if c.Stdout != "" {
+		session.Setenv(util.PULUMI_COMMAND_STDOUT, c.Stdout)
+	}
+	if c.Stderr != "" {
+		session.Setenv(util.PULUMI_COMMAND_STDERR, c.Stderr)
+	}
 
 	if c.Stdin != nil && len(*c.Stdin) > 0 {
 		session.Stdin = strings.NewReader(*c.Stdin)

--- a/provider/pkg/provider/util/util.go
+++ b/provider/pkg/provider/util/util.go
@@ -22,6 +22,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 )
 
+const PULUMI_COMMAND_STDOUT = "PULUMI_COMMAND_STDOUT"
+const PULUMI_COMMAND_STDERR = "PULUMI_COMMAND_STDERR"
+
 func CopyOutput(ctx p.Context, r io.Reader, doneCh chan<- struct{}, severity diag.Severity) {
 	defer close(doneCh)
 	scanner := bufio.NewScanner(r)

--- a/sdk/dotnet/Local/Command.cs
+++ b/sdk/dotnet/Local/Command.cs
@@ -125,7 +125,9 @@ namespace Pulumi.Command.Local
         public Output<string?> Create { get; private set; } = null!;
 
         /// <summary>
-        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        /// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        /// Command resource from previous create or update steps.
         /// </summary>
         [Output("delete")]
         public Output<string?> Delete { get; private set; } = null!;
@@ -175,7 +177,10 @@ namespace Pulumi.Command.Local
         public Output<ImmutableArray<object>> Triggers { get; private set; } = null!;
 
         /// <summary>
-        /// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        /// The command to run on update, if empty, create will 
+        /// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        /// are set to the stdout and stderr properties of the Command resource from previous 
+        /// create or update steps.
         /// </summary>
         [Output("update")]
         public Output<string?> Update { get; private set; } = null!;
@@ -334,7 +339,9 @@ namespace Pulumi.Command.Local
         public Input<string>? Create { get; set; }
 
         /// <summary>
-        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        /// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        /// Command resource from previous create or update steps.
         /// </summary>
         [Input("delete")]
         public Input<string>? Delete { get; set; }
@@ -390,7 +397,10 @@ namespace Pulumi.Command.Local
         }
 
         /// <summary>
-        /// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        /// The command to run on update, if empty, create will 
+        /// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        /// are set to the stdout and stderr properties of the Command resource from previous 
+        /// create or update steps.
         /// </summary>
         [Input("update")]
         public Input<string>? Update { get; set; }

--- a/sdk/dotnet/Local/Command.cs
+++ b/sdk/dotnet/Local/Command.cs
@@ -125,7 +125,7 @@ namespace Pulumi.Command.Local
         public Output<string?> Create { get; private set; } = null!;
 
         /// <summary>
-        /// The command to run on delete.
+        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         /// </summary>
         [Output("delete")]
         public Output<string?> Delete { get; private set; } = null!;
@@ -175,7 +175,7 @@ namespace Pulumi.Command.Local
         public Output<ImmutableArray<object>> Triggers { get; private set; } = null!;
 
         /// <summary>
-        /// The command to run on update, if empty, create will run again.
+        /// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         /// </summary>
         [Output("update")]
         public Output<string?> Update { get; private set; } = null!;
@@ -334,7 +334,7 @@ namespace Pulumi.Command.Local
         public Input<string>? Create { get; set; }
 
         /// <summary>
-        /// The command to run on delete.
+        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         /// </summary>
         [Input("delete")]
         public Input<string>? Delete { get; set; }
@@ -390,7 +390,7 @@ namespace Pulumi.Command.Local
         }
 
         /// <summary>
-        /// The command to run on update, if empty, create will run again.
+        /// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         /// </summary>
         [Input("update")]
         public Input<string>? Update { get; set; }

--- a/sdk/dotnet/Remote/Command.cs
+++ b/sdk/dotnet/Remote/Command.cs
@@ -29,7 +29,9 @@ namespace Pulumi.Command.Remote
         public Output<string?> Create { get; private set; } = null!;
 
         /// <summary>
-        /// The command to run on delete.
+        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        /// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        /// Command resource from previous create or update steps.
         /// </summary>
         [Output("delete")]
         public Output<string?> Delete { get; private set; } = null!;
@@ -65,7 +67,10 @@ namespace Pulumi.Command.Remote
         public Output<ImmutableArray<object>> Triggers { get; private set; } = null!;
 
         /// <summary>
-        /// The command to run on update, if empty, create will run again.
+        /// The command to run on update, if empty, create will 
+        /// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        /// are set to the stdout and stderr properties of the Command resource from previous 
+        /// create or update steps.
         /// </summary>
         [Output("update")]
         public Output<string?> Update { get; private set; } = null!;
@@ -146,7 +151,9 @@ namespace Pulumi.Command.Remote
         public Input<string>? Create { get; set; }
 
         /// <summary>
-        /// The command to run on delete.
+        /// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        /// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        /// Command resource from previous create or update steps.
         /// </summary>
         [Input("delete")]
         public Input<string>? Delete { get; set; }
@@ -182,7 +189,10 @@ namespace Pulumi.Command.Remote
         }
 
         /// <summary>
-        /// The command to run on update, if empty, create will run again.
+        /// The command to run on update, if empty, create will 
+        /// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        /// are set to the stdout and stderr properties of the Command resource from previous 
+        /// create or update steps.
         /// </summary>
         [Input("update")]
         public Input<string>? Update { get; set; }

--- a/sdk/go/command/local/command.go
+++ b/sdk/go/command/local/command.go
@@ -65,7 +65,7 @@ type Command struct {
 	Assets pulumi.AssetOrArchiveMapOutput `pulumi:"assets"`
 	// The command to run on create.
 	Create pulumi.StringPtrOutput `pulumi:"create"`
-	// The command to run on delete.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 	Delete pulumi.StringPtrOutput `pulumi:"delete"`
 	// The directory from which to run the command from. If `dir` does not exist, then
 	// `Command` will fail.
@@ -83,7 +83,7 @@ type Command struct {
 	Stdout pulumi.StringOutput `pulumi:"stdout"`
 	// Trigger replacements on changes to this input.
 	Triggers pulumi.ArrayOutput `pulumi:"triggers"`
-	// The command to run on update, if empty, create will run again.
+	// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 	Update pulumi.StringPtrOutput `pulumi:"update"`
 }
 
@@ -172,7 +172,7 @@ type commandArgs struct {
 	AssetPaths []string `pulumi:"assetPaths"`
 	// The command to run on create.
 	Create *string `pulumi:"create"`
-	// The command to run on delete.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 	Delete *string `pulumi:"delete"`
 	// The directory from which to run the command from. If `dir` does not exist, then
 	// `Command` will fail.
@@ -186,7 +186,7 @@ type commandArgs struct {
 	Stdin *string `pulumi:"stdin"`
 	// Trigger replacements on changes to this input.
 	Triggers []interface{} `pulumi:"triggers"`
-	// The command to run on update, if empty, create will run again.
+	// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 	Update *string `pulumi:"update"`
 }
 
@@ -234,7 +234,7 @@ type CommandArgs struct {
 	AssetPaths pulumi.StringArrayInput
 	// The command to run on create.
 	Create pulumi.StringPtrInput
-	// The command to run on delete.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 	Delete pulumi.StringPtrInput
 	// The directory from which to run the command from. If `dir` does not exist, then
 	// `Command` will fail.
@@ -248,7 +248,7 @@ type CommandArgs struct {
 	Stdin pulumi.StringPtrInput
 	// Trigger replacements on changes to this input.
 	Triggers pulumi.ArrayInput
-	// The command to run on update, if empty, create will run again.
+	// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 	Update pulumi.StringPtrInput
 }
 
@@ -401,7 +401,7 @@ func (o CommandOutput) Create() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Create }).(pulumi.StringPtrOutput)
 }
 
-// The command to run on delete.
+// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 func (o CommandOutput) Delete() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Delete }).(pulumi.StringPtrOutput)
 }
@@ -443,7 +443,7 @@ func (o CommandOutput) Triggers() pulumi.ArrayOutput {
 	return o.ApplyT(func(v *Command) pulumi.ArrayOutput { return v.Triggers }).(pulumi.ArrayOutput)
 }
 
-// The command to run on update, if empty, create will run again.
+// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
 func (o CommandOutput) Update() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Update }).(pulumi.StringPtrOutput)
 }

--- a/sdk/go/command/local/command.go
+++ b/sdk/go/command/local/command.go
@@ -65,7 +65,9 @@ type Command struct {
 	Assets pulumi.AssetOrArchiveMapOutput `pulumi:"assets"`
 	// The command to run on create.
 	Create pulumi.StringPtrOutput `pulumi:"create"`
-	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrOutput `pulumi:"delete"`
 	// The directory from which to run the command from. If `dir` does not exist, then
 	// `Command` will fail.
@@ -83,7 +85,10 @@ type Command struct {
 	Stdout pulumi.StringOutput `pulumi:"stdout"`
 	// Trigger replacements on changes to this input.
 	Triggers pulumi.ArrayOutput `pulumi:"triggers"`
-	// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+	// The command to run on update, if empty, create will
+	// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+	// are set to the stdout and stderr properties of the Command resource from previous
+	// create or update steps.
 	Update pulumi.StringPtrOutput `pulumi:"update"`
 }
 
@@ -172,7 +177,9 @@ type commandArgs struct {
 	AssetPaths []string `pulumi:"assetPaths"`
 	// The command to run on create.
 	Create *string `pulumi:"create"`
-	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+	// Command resource from previous create or update steps.
 	Delete *string `pulumi:"delete"`
 	// The directory from which to run the command from. If `dir` does not exist, then
 	// `Command` will fail.
@@ -186,7 +193,10 @@ type commandArgs struct {
 	Stdin *string `pulumi:"stdin"`
 	// Trigger replacements on changes to this input.
 	Triggers []interface{} `pulumi:"triggers"`
-	// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+	// The command to run on update, if empty, create will
+	// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+	// are set to the stdout and stderr properties of the Command resource from previous
+	// create or update steps.
 	Update *string `pulumi:"update"`
 }
 
@@ -234,7 +244,9 @@ type CommandArgs struct {
 	AssetPaths pulumi.StringArrayInput
 	// The command to run on create.
 	Create pulumi.StringPtrInput
-	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrInput
 	// The directory from which to run the command from. If `dir` does not exist, then
 	// `Command` will fail.
@@ -248,7 +260,10 @@ type CommandArgs struct {
 	Stdin pulumi.StringPtrInput
 	// Trigger replacements on changes to this input.
 	Triggers pulumi.ArrayInput
-	// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+	// The command to run on update, if empty, create will
+	// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+	// are set to the stdout and stderr properties of the Command resource from previous
+	// create or update steps.
 	Update pulumi.StringPtrInput
 }
 
@@ -401,7 +416,9 @@ func (o CommandOutput) Create() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Create }).(pulumi.StringPtrOutput)
 }
 
-// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+// Command resource from previous create or update steps.
 func (o CommandOutput) Delete() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Delete }).(pulumi.StringPtrOutput)
 }
@@ -443,7 +460,10 @@ func (o CommandOutput) Triggers() pulumi.ArrayOutput {
 	return o.ApplyT(func(v *Command) pulumi.ArrayOutput { return v.Triggers }).(pulumi.ArrayOutput)
 }
 
-// The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+// The command to run on update, if empty, create will
+// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+// are set to the stdout and stderr properties of the Command resource from previous
+// create or update steps.
 func (o CommandOutput) Update() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Update }).(pulumi.StringPtrOutput)
 }

--- a/sdk/go/command/remote/command.go
+++ b/sdk/go/command/remote/command.go
@@ -20,7 +20,9 @@ type Command struct {
 	Connection ConnectionOutput `pulumi:"connection"`
 	// The command to run on create.
 	Create pulumi.StringPtrOutput `pulumi:"create"`
-	// The command to run on delete.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrOutput `pulumi:"delete"`
 	// Additional environment variables available to the command's process.
 	Environment pulumi.StringMapOutput `pulumi:"environment"`
@@ -32,7 +34,10 @@ type Command struct {
 	Stdout pulumi.StringOutput `pulumi:"stdout"`
 	// Trigger replacements on changes to this input.
 	Triggers pulumi.ArrayOutput `pulumi:"triggers"`
-	// The command to run on update, if empty, create will run again.
+	// The command to run on update, if empty, create will
+	// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+	// are set to the stdout and stderr properties of the Command resource from previous
+	// create or update steps.
 	Update pulumi.StringPtrOutput `pulumi:"update"`
 }
 
@@ -94,7 +99,9 @@ type commandArgs struct {
 	Connection Connection `pulumi:"connection"`
 	// The command to run on create.
 	Create *string `pulumi:"create"`
-	// The command to run on delete.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+	// Command resource from previous create or update steps.
 	Delete *string `pulumi:"delete"`
 	// Additional environment variables available to the command's process.
 	Environment map[string]string `pulumi:"environment"`
@@ -102,7 +109,10 @@ type commandArgs struct {
 	Stdin *string `pulumi:"stdin"`
 	// Trigger replacements on changes to this input.
 	Triggers []interface{} `pulumi:"triggers"`
-	// The command to run on update, if empty, create will run again.
+	// The command to run on update, if empty, create will
+	// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+	// are set to the stdout and stderr properties of the Command resource from previous
+	// create or update steps.
 	Update *string `pulumi:"update"`
 }
 
@@ -112,7 +122,9 @@ type CommandArgs struct {
 	Connection ConnectionInput
 	// The command to run on create.
 	Create pulumi.StringPtrInput
-	// The command to run on delete.
+	// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrInput
 	// Additional environment variables available to the command's process.
 	Environment pulumi.StringMapInput
@@ -120,7 +132,10 @@ type CommandArgs struct {
 	Stdin pulumi.StringPtrInput
 	// Trigger replacements on changes to this input.
 	Triggers pulumi.ArrayInput
-	// The command to run on update, if empty, create will run again.
+	// The command to run on update, if empty, create will
+	// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+	// are set to the stdout and stderr properties of the Command resource from previous
+	// create or update steps.
 	Update pulumi.StringPtrInput
 }
 
@@ -221,7 +236,9 @@ func (o CommandOutput) Create() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Create }).(pulumi.StringPtrOutput)
 }
 
-// The command to run on delete.
+// The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+// Command resource from previous create or update steps.
 func (o CommandOutput) Delete() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Delete }).(pulumi.StringPtrOutput)
 }
@@ -251,7 +268,10 @@ func (o CommandOutput) Triggers() pulumi.ArrayOutput {
 	return o.ApplyT(func(v *Command) pulumi.ArrayOutput { return v.Triggers }).(pulumi.ArrayOutput)
 }
 
-// The command to run on update, if empty, create will run again.
+// The command to run on update, if empty, create will
+// run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+// are set to the stdout and stderr properties of the Command resource from previous
+// create or update steps.
 func (o CommandOutput) Update() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringPtrOutput { return v.Update }).(pulumi.StringPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/command/local/Command.java
+++ b/sdk/java/src/main/java/com/pulumi/command/local/Command.java
@@ -173,14 +173,14 @@ public class Command extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.create);
     }
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     @Export(name="delete", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> delete;
 
     /**
-     * @return The command to run on delete.
+     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     public Output<Optional<String>> delete() {
@@ -289,14 +289,14 @@ public class Command extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.triggers);
     }
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     @Export(name="update", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> update;
 
     /**
-     * @return The command to run on update, if empty, create will run again.
+     * @return The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     public Output<Optional<String>> update() {

--- a/sdk/java/src/main/java/com/pulumi/command/local/Command.java
+++ b/sdk/java/src/main/java/com/pulumi/command/local/Command.java
@@ -173,14 +173,18 @@ public class Command extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.create);
     }
     /**
-     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     @Export(name="delete", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> delete;
 
     /**
-     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     public Output<Optional<String>> delete() {
@@ -289,14 +293,20 @@ public class Command extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.triggers);
     }
     /**
-     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     @Export(name="update", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> update;
 
     /**
-     * @return The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * @return The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     public Output<Optional<String>> update() {

--- a/sdk/java/src/main/java/com/pulumi/command/local/CommandArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/command/local/CommandArgs.java
@@ -136,14 +136,14 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     @Import(name="delete")
     private @Nullable Output<String> delete;
 
     /**
-     * @return The command to run on delete.
+     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     public Optional<Output<String>> delete() {
@@ -230,14 +230,14 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     @Import(name="update")
     private @Nullable Output<String> update;
 
     /**
-     * @return The command to run on update, if empty, create will run again.
+     * @return The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      * 
      */
     public Optional<Output<String>> update() {
@@ -469,7 +469,7 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param delete The command to run on delete.
+         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -480,7 +480,7 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param delete The command to run on delete.
+         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -620,7 +620,7 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param update The command to run on update, if empty, create will run again.
+         * @param update The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -631,7 +631,7 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param update The command to run on update, if empty, create will run again.
+         * @param update The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/command/local/CommandArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/command/local/CommandArgs.java
@@ -136,14 +136,18 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     @Import(name="delete")
     private @Nullable Output<String> delete;
 
     /**
-     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     public Optional<Output<String>> delete() {
@@ -230,14 +234,20 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     @Import(name="update")
     private @Nullable Output<String> update;
 
     /**
-     * @return The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * @return The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     public Optional<Output<String>> update() {
@@ -469,7 +479,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+         * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+         * Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -480,7 +492,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+         * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+         * Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -620,7 +634,10 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param update The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+         * @param update The command to run on update, if empty, create will
+         * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+         * are set to the stdout and stderr properties of the Command resource from previous
+         * create or update steps.
          * 
          * @return builder
          * 
@@ -631,7 +648,10 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param update The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+         * @param update The command to run on update, if empty, create will
+         * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+         * are set to the stdout and stderr properties of the Command resource from previous
+         * create or update steps.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/command/remote/Command.java
+++ b/sdk/java/src/main/java/com/pulumi/command/remote/Command.java
@@ -53,14 +53,18 @@ public class Command extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.create);
     }
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     @Export(name="delete", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> delete;
 
     /**
-     * @return The command to run on delete.
+     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     public Output<Optional<String>> delete() {
@@ -137,14 +141,20 @@ public class Command extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.triggers);
     }
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     @Export(name="update", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> update;
 
     /**
-     * @return The command to run on update, if empty, create will run again.
+     * @return The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     public Output<Optional<String>> update() {

--- a/sdk/java/src/main/java/com/pulumi/command/remote/CommandArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/command/remote/CommandArgs.java
@@ -50,14 +50,18 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     @Import(name="delete")
     private @Nullable Output<String> delete;
 
     /**
-     * @return The command to run on delete.
+     * @return The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      * 
      */
     public Optional<Output<String>> delete() {
@@ -110,14 +114,20 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     @Import(name="update")
     private @Nullable Output<String> update;
 
     /**
-     * @return The command to run on update, if empty, create will run again.
+     * @return The command to run on update, if empty, create will
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+     * are set to the stdout and stderr properties of the Command resource from previous
+     * create or update steps.
      * 
      */
     public Optional<Output<String>> update() {
@@ -197,7 +207,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param delete The command to run on delete.
+         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+         * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+         * Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -208,7 +220,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param delete The command to run on delete.
+         * @param delete The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+         * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+         * Command resource from previous create or update steps.
          * 
          * @return builder
          * 
@@ -291,7 +305,10 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param update The command to run on update, if empty, create will run again.
+         * @param update The command to run on update, if empty, create will
+         * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+         * are set to the stdout and stderr properties of the Command resource from previous
+         * create or update steps.
          * 
          * @return builder
          * 
@@ -302,7 +319,10 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param update The command to run on update, if empty, create will run again.
+         * @param update The command to run on update, if empty, create will
+         * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR
+         * are set to the stdout and stderr properties of the Command resource from previous
+         * create or update steps.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/local/command.ts
+++ b/sdk/nodejs/local/command.ts
@@ -134,7 +134,9 @@ export class Command extends pulumi.CustomResource {
      */
     public readonly create!: pulumi.Output<string | undefined>;
     /**
-     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      */
     public readonly delete!: pulumi.Output<string | undefined>;
     /**
@@ -168,7 +170,10 @@ export class Command extends pulumi.CustomResource {
      */
     public readonly triggers!: pulumi.Output<any[] | undefined>;
     /**
-     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on update, if empty, create will 
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+     * are set to the stdout and stderr properties of the Command resource from previous 
+     * create or update steps.
      */
     public readonly update!: pulumi.Output<string | undefined>;
 
@@ -311,7 +316,9 @@ export interface CommandArgs {
      */
     create?: pulumi.Input<string>;
     /**
-     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      */
     delete?: pulumi.Input<string>;
     /**
@@ -337,7 +344,10 @@ export interface CommandArgs {
      */
     triggers?: pulumi.Input<any[]>;
     /**
-     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+     * The command to run on update, if empty, create will 
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+     * are set to the stdout and stderr properties of the Command resource from previous 
+     * create or update steps.
      */
     update?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/local/command.ts
+++ b/sdk/nodejs/local/command.ts
@@ -134,7 +134,7 @@ export class Command extends pulumi.CustomResource {
      */
     public readonly create!: pulumi.Output<string | undefined>;
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      */
     public readonly delete!: pulumi.Output<string | undefined>;
     /**
@@ -168,7 +168,7 @@ export class Command extends pulumi.CustomResource {
      */
     public readonly triggers!: pulumi.Output<any[] | undefined>;
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      */
     public readonly update!: pulumi.Output<string | undefined>;
 
@@ -311,7 +311,7 @@ export interface CommandArgs {
      */
     create?: pulumi.Input<string>;
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      */
     delete?: pulumi.Input<string>;
     /**
@@ -337,7 +337,7 @@ export interface CommandArgs {
      */
     triggers?: pulumi.Input<any[]>;
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
      */
     update?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/remote/command.ts
+++ b/sdk/nodejs/remote/command.ts
@@ -46,7 +46,9 @@ export class Command extends pulumi.CustomResource {
      */
     public readonly create!: pulumi.Output<string | undefined>;
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      */
     public readonly delete!: pulumi.Output<string | undefined>;
     /**
@@ -70,7 +72,10 @@ export class Command extends pulumi.CustomResource {
      */
     public readonly triggers!: pulumi.Output<any[] | undefined>;
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will 
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+     * are set to the stdout and stderr properties of the Command resource from previous 
+     * create or update steps.
      */
     public readonly update!: pulumi.Output<string | undefined>;
 
@@ -130,7 +135,9 @@ export interface CommandArgs {
      */
     create?: pulumi.Input<string>;
     /**
-     * The command to run on delete.
+     * The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+     * and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+     * Command resource from previous create or update steps.
      */
     delete?: pulumi.Input<string>;
     /**
@@ -146,7 +153,10 @@ export interface CommandArgs {
      */
     triggers?: pulumi.Input<any[]>;
     /**
-     * The command to run on update, if empty, create will run again.
+     * The command to run on update, if empty, create will 
+     * run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+     * are set to the stdout and stderr properties of the Command resource from previous 
+     * create or update steps.
      */
     update?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_command/local/command.py
+++ b/sdk/python/pulumi_command/local/command.py
@@ -103,7 +103,9 @@ class CommandArgs:
                - src/index.js
                ```
         :param pulumi.Input[str] create: The command to run on create.
-        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+               and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+               Command resource from previous create or update steps.
         :param pulumi.Input[str] dir: The directory from which to run the command from. If `dir` does not exist, then
                `Command` will fail.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
@@ -111,7 +113,10 @@ class CommandArgs:
                On Linux and macOS, defaults to: `["/bin/sh", "-c"]`. On Windows, defaults to: `["cmd", "/C"]`
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
-        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        :param pulumi.Input[str] update: The command to run on update, if empty, create will 
+               run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+               are set to the stdout and stderr properties of the Command resource from previous 
+               create or update steps.
         """
         if archive_paths is not None:
             pulumi.set(__self__, "archive_paths", archive_paths)
@@ -248,7 +253,9 @@ class CommandArgs:
     @pulumi.getter
     def delete(self) -> Optional[pulumi.Input[str]]:
         """
-        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
 
@@ -322,7 +329,10 @@ class CommandArgs:
     @pulumi.getter
     def update(self) -> Optional[pulumi.Input[str]]:
         """
-        The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        The command to run on update, if empty, create will 
+        run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        are set to the stdout and stderr properties of the Command resource from previous 
+        create or update steps.
         """
         return pulumi.get(self, "update")
 
@@ -433,7 +443,9 @@ class Command(pulumi.CustomResource):
                - src/index.js
                ```
         :param pulumi.Input[str] create: The command to run on create.
-        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+               and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+               Command resource from previous create or update steps.
         :param pulumi.Input[str] dir: The directory from which to run the command from. If `dir` does not exist, then
                `Command` will fail.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
@@ -441,7 +453,10 @@ class Command(pulumi.CustomResource):
                On Linux and macOS, defaults to: `["/bin/sh", "-c"]`. On Windows, defaults to: `["cmd", "/C"]`
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
-        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        :param pulumi.Input[str] update: The command to run on update, if empty, create will 
+               run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+               are set to the stdout and stderr properties of the Command resource from previous 
+               create or update steps.
         """
         ...
     @overload
@@ -663,7 +678,9 @@ class Command(pulumi.CustomResource):
     @pulumi.getter
     def delete(self) -> pulumi.Output[Optional[str]]:
         """
-        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
 
@@ -729,7 +746,10 @@ class Command(pulumi.CustomResource):
     @pulumi.getter
     def update(self) -> pulumi.Output[Optional[str]]:
         """
-        The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
+        The command to run on update, if empty, create will 
+        run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        are set to the stdout and stderr properties of the Command resource from previous 
+        create or update steps.
         """
         return pulumi.get(self, "update")
 

--- a/sdk/python/pulumi_command/local/command.py
+++ b/sdk/python/pulumi_command/local/command.py
@@ -103,7 +103,7 @@ class CommandArgs:
                - src/index.js
                ```
         :param pulumi.Input[str] create: The command to run on create.
-        :param pulumi.Input[str] delete: The command to run on delete.
+        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         :param pulumi.Input[str] dir: The directory from which to run the command from. If `dir` does not exist, then
                `Command` will fail.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
@@ -111,7 +111,7 @@ class CommandArgs:
                On Linux and macOS, defaults to: `["/bin/sh", "-c"]`. On Windows, defaults to: `["cmd", "/C"]`
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
-        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again.
+        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         """
         if archive_paths is not None:
             pulumi.set(__self__, "archive_paths", archive_paths)
@@ -248,7 +248,7 @@ class CommandArgs:
     @pulumi.getter
     def delete(self) -> Optional[pulumi.Input[str]]:
         """
-        The command to run on delete.
+        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
 
@@ -322,7 +322,7 @@ class CommandArgs:
     @pulumi.getter
     def update(self) -> Optional[pulumi.Input[str]]:
         """
-        The command to run on update, if empty, create will run again.
+        The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         """
         return pulumi.get(self, "update")
 
@@ -433,7 +433,7 @@ class Command(pulumi.CustomResource):
                - src/index.js
                ```
         :param pulumi.Input[str] create: The command to run on create.
-        :param pulumi.Input[str] delete: The command to run on delete.
+        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         :param pulumi.Input[str] dir: The directory from which to run the command from. If `dir` does not exist, then
                `Command` will fail.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
@@ -441,7 +441,7 @@ class Command(pulumi.CustomResource):
                On Linux and macOS, defaults to: `["/bin/sh", "-c"]`. On Windows, defaults to: `["cmd", "/C"]`
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
-        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again.
+        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         """
         ...
     @overload
@@ -663,7 +663,7 @@ class Command(pulumi.CustomResource):
     @pulumi.getter
     def delete(self) -> pulumi.Output[Optional[str]]:
         """
-        The command to run on delete.
+        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
 
@@ -729,7 +729,7 @@ class Command(pulumi.CustomResource):
     @pulumi.getter
     def update(self) -> pulumi.Output[Optional[str]]:
         """
-        The command to run on update, if empty, create will run again.
+        The command to run on update, if empty, create will run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the Command resource from previous create or update steps.
         """
         return pulumi.get(self, "update")
 

--- a/sdk/python/pulumi_command/remote/command.py
+++ b/sdk/python/pulumi_command/remote/command.py
@@ -27,11 +27,16 @@ class CommandArgs:
         The set of arguments for constructing a Command resource.
         :param pulumi.Input['ConnectionArgs'] connection: The parameters with which to connect to the remote host.
         :param pulumi.Input[str] create: The command to run on create.
-        :param pulumi.Input[str] delete: The command to run on delete.
+        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+               and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+               Command resource from previous create or update steps.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
-        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again.
+        :param pulumi.Input[str] update: The command to run on update, if empty, create will 
+               run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+               are set to the stdout and stderr properties of the Command resource from previous 
+               create or update steps.
         """
         pulumi.set(__self__, "connection", connection)
         if create is not None:
@@ -75,7 +80,9 @@ class CommandArgs:
     @pulumi.getter
     def delete(self) -> Optional[pulumi.Input[str]]:
         """
-        The command to run on delete.
+        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
 
@@ -123,7 +130,10 @@ class CommandArgs:
     @pulumi.getter
     def update(self) -> Optional[pulumi.Input[str]]:
         """
-        The command to run on update, if empty, create will run again.
+        The command to run on update, if empty, create will 
+        run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        are set to the stdout and stderr properties of the Command resource from previous 
+        create or update steps.
         """
         return pulumi.get(self, "update")
 
@@ -153,11 +163,16 @@ class Command(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[pulumi.InputType['ConnectionArgs']] connection: The parameters with which to connect to the remote host.
         :param pulumi.Input[str] create: The command to run on create.
-        :param pulumi.Input[str] delete: The command to run on delete.
+        :param pulumi.Input[str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+               and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+               Command resource from previous create or update steps.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
-        :param pulumi.Input[str] update: The command to run on update, if empty, create will run again.
+        :param pulumi.Input[str] update: The command to run on update, if empty, create will 
+               run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+               are set to the stdout and stderr properties of the Command resource from previous 
+               create or update steps.
         """
         ...
     @overload
@@ -268,7 +283,9 @@ class Command(pulumi.CustomResource):
     @pulumi.getter
     def delete(self) -> pulumi.Output[Optional[str]]:
         """
-        The command to run on delete.
+        The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
+        and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
+        Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
 
@@ -316,7 +333,10 @@ class Command(pulumi.CustomResource):
     @pulumi.getter
     def update(self) -> pulumi.Output[Optional[str]]:
         """
-        The command to run on update, if empty, create will run again.
+        The command to run on update, if empty, create will 
+        run again. The environment variables PULUMI_COMMAND_STDOUT and PULUMI_COMMAND_STDERR 
+        are set to the stdout and stderr properties of the Command resource from previous 
+        create or update steps.
         """
         return pulumi.get(self, "update")
 


### PR DESCRIPTION
Fixes #167.
