### PR TITLE
Improve stdout/stderr handling

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -64,7 +64,7 @@ func TestStderr(t *testing.T) {
 						case diag.Error:
 							if ev.DiagnosticEvent.URN != "" {
 								assert.False(t, ev.DiagnosticEvent.Ephemeral)
-								assert.Regexp(t, "^exit status %d: running", ev.DiagnosticEvent.Message)
+								assert.Regexp(t, `^exit status \d+: running`, ev.DiagnosticEvent.Message)
 							}
 						}
 					}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -41,6 +42,33 @@ func TestDeleteFromStdout(t *testing.T) {
 				assert.True(t, ok)
 				_, err := os.Stat(out)
 				assert.NoError(t, err)
+			},
+		})
+	integration.ProgramTest(t, &test)
+}
+
+func TestStderr(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:                    filepath.Join(getCwd(t), "stderr"),
+			SkipPreview:            true,
+			SkipRefresh:            true,
+			SkipEmptyPreviewUpdate: true,
+			ExpectFailure:          true,
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				for _, ev := range stack.Events {
+					if ev.DiagnosticEvent != nil {
+						switch diag.Severity(ev.DiagnosticEvent.Severity) {
+						case diag.Info:
+							assert.True(t, ev.DiagnosticEvent.Ephemeral)
+						case diag.Error:
+							if ev.DiagnosticEvent.URN != "" {
+								assert.False(t, ev.DiagnosticEvent.Ephemeral)
+								assert.Regexp(t, "^exit status %d: running", ev.DiagnosticEvent.Message)
+							}
+						}
+					}
+				}
 			},
 		})
 	integration.ProgramTest(t, &test)

--- a/examples/simple-run/index.ts
+++ b/examples/simple-run/index.ts
@@ -2,7 +2,7 @@ import * as local from "@pulumi/command/local";
 import * as random from "@pulumi/random";
 import { interpolate } from "@pulumi/pulumi";
 
-const pw = new random.RandomPassword("pw", { length: 10 });
+const pw = new random.RandomPassword("pw", { length: 10, special: false });
 
 const plainFile = local.runOutput({
     command: `echo "Hello world!" > hello.txt`,

--- a/examples/simple-with-update/index.ts
+++ b/examples/simple-with-update/index.ts
@@ -3,7 +3,7 @@ import * as random from "@pulumi/random";
 import { interpolate } from "@pulumi/pulumi";
 import { len, fail, update } from "./extras";
 
-const pw = new random.RandomPassword("pw", { length: len });
+const pw = new random.RandomPassword("pw", { length: len, special: false });
 
 const pwd = new local.Command("pwd", {
     create: interpolate`touch "${pw.result}cat.txt"`,

--- a/examples/simple-with-update/update-change/index.ts
+++ b/examples/simple-with-update/update-change/index.ts
@@ -3,7 +3,7 @@ import * as random from "@pulumi/random";
 import { interpolate } from "@pulumi/pulumi";
 import { len, fail, update } from "./extras";
 
-const pw = new random.RandomPassword("pw", { length: len });
+const pw = new random.RandomPassword("pw", { length: len, special: false });
 
 const pwd = new local.Command("pwd", {
     create: interpolate`touch "${pw.result}cat.txt"`,

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -3,7 +3,7 @@ import * as random from "@pulumi/random";
 import { interpolate } from "@pulumi/pulumi";
 import { len, fail, update } from "./extras";
 
-const pw = new random.RandomPassword("pw", { length: len });
+const pw = new random.RandomPassword("pw", { length: len, special: false });
 
 const pwd = new local.Command("pwd", {
     create: interpolate`echo "${pw.result}" > password.txt`,

--- a/examples/stderr/Pulumi.yaml
+++ b/examples/stderr/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: command-stderr
+runtime: nodejs
+description: A simple command example

--- a/examples/stderr/index.ts
+++ b/examples/stderr/index.ts
@@ -1,0 +1,9 @@
+import * as command from "@pulumi/command";
+
+new command.local.Command("stdout-and-stderr-success", {
+  create: "ls not-a-file index.ts not-a-file-2 || true"
+});
+
+new command.local.Command("stdout-and-stderr-error", {
+    create: "ls not-a-file index.ts not-a-file-2"
+  });

--- a/examples/stderr/package.json
+++ b/examples/stderr/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "command-stderr",
+    "version": "0.1.0",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/random": "^4.2.0"
+    }
+}

--- a/examples/stderr/tsconfig.json
+++ b/examples/stderr/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/pkg/provider/local/commandOutputs.go
+++ b/provider/pkg/provider/local/commandOutputs.go
@@ -48,11 +48,12 @@ func (c *CommandOutputs) run(ctx p.Context, command string) (string, string, err
 
 	var err error
 	var stdoutbuf, stderrbuf, stdouterrbuf bytes.Buffer
+	stdouterrwriter := util.ConcurrentWriter{Writer: &stdouterrbuf}
 	r, w := io.Pipe()
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	cmd.Stdout = io.MultiWriter(&stdoutbuf, &stdouterrbuf, w)
-	cmd.Stderr = io.MultiWriter(&stderrbuf, &stdouterrbuf, w)
+	cmd.Stdout = io.MultiWriter(&stdoutbuf, &stdouterrwriter, w)
+	cmd.Stderr = io.MultiWriter(&stderrbuf, &stdouterrwriter, w)
 	if c.Dir != nil {
 		cmd.Dir = *c.Dir
 	} else {

--- a/provider/pkg/provider/util/util.go
+++ b/provider/pkg/provider/util/util.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bufio"
 	"io"
+	"sync"
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -31,4 +32,15 @@ func CopyOutput(ctx p.Context, r io.Reader, doneCh chan<- struct{}, severity dia
 	for scanner.Scan() {
 		ctx.LogStatus(severity, scanner.Text())
 	}
+}
+
+type ConcurrentWriter struct {
+	Writer io.Writer
+	mu     sync.Mutex
+}
+
+func (w *ConcurrentWriter) Write(bs []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.Writer.Write(bs)
 }

--- a/provider/pkg/provider/util/util.go
+++ b/provider/pkg/provider/util/util.go
@@ -29,6 +29,6 @@ func CopyOutput(ctx p.Context, r io.Reader, doneCh chan<- struct{}, severity dia
 	defer close(doneCh)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		ctx.Log(severity, scanner.Text())
+		ctx.LogStatus(severity, scanner.Text())
 	}
 }


### PR DESCRIPTION
This overhauls the treatment of stdout and stderr for local.Command and remote.Command.

The new rules are:
1. stdout and stderr are both rendered directly to ephemeral logs always.
2. when the command fails, the resource creation fails, and the returned error message includes the full combined text of stdout+stderr (along with the exit code and the command that was run).
3. the stdout and stderr properties of the resource are still populated with the values of those output streams if the command succeeds.

In the future, we may want to support an option to suppress (1) for cases where the command output if overly verbose, but it is better to include it by default (similar to the docker.Image component).

Fixes #80.
Fixes #121.