### PR TITLE
cmd/gen: Don't take two passes over JSON

### DIFF
--- a/provider/cmd/pulumi-gen-command/main.go
+++ b/provider/cmd/pulumi-gen-command/main.go
@@ -27,26 +27,17 @@ import (
 
 // copied from encoding/json for use with JSONMarshal above
 func MarshalIndent(v any) ([]byte, error) {
-
 	// json.Marshal normally escapes HTML. This one doesn't
 	// https://stackoverflow.com/questions/28595664/how-to-stop-json-marshal-from-escaping-and
-	buffer := &bytes.Buffer{}
-	encoder := json.NewEncoder(buffer)
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
 	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "    ")
 	err := encoder.Encode(v)
 	if err != nil {
 		return nil, err
 	}
-	b := buffer.Bytes()
-
-	// serialize and pretty print
-	var buf bytes.Buffer
-	prefix, indent := "", "    "
-	err = json.Indent(&buf, b, prefix, indent)
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return buffer.Bytes(), nil
 }
 
 func main() {


### PR DESCRIPTION
MarshalIndent JSON-encodes the input,
and then passes it through `json.Indent` again
to indent it properly.

This isn't necessary.
`json.Encoder` has a `SetIndent` method
that allows opting into indentation in the first pass.

Test Plan:
Verified `make codegen` leaves the schema unchanged.
