### PR TITLE
Fix stdout and stderr missing in pulumi update command

### DIFF
--- a/examples/delete-from-stdout/index.ts
+++ b/examples/delete-from-stdout/index.ts
@@ -2,6 +2,7 @@ import { local } from "@pulumi/command";
 
 const mktemp = new local.Command('mktemp', {
     create: 'mktemp',
+    update: 'echo $PULUMI_COMMAND_STDOUT',
     delete: 'rm $PULUMI_COMMAND_STDOUT'
 })
 

--- a/examples/delete-from-stdout/package.json
+++ b/examples/delete-from-stdout/package.json
@@ -5,7 +5,6 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/command": "^0.7.1",
         "@pulumi/pulumi": "latest",
         "@pulumi/random": "^4.2.0"
     }

--- a/examples/delete-from-stdout/package.json
+++ b/examples/delete-from-stdout/package.json
@@ -5,6 +5,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
+        "@pulumi/command": "^0.7.1",
         "@pulumi/pulumi": "latest",
         "@pulumi/random": "^4.2.0"
     }

--- a/provider/pkg/provider/local/commandController.go
+++ b/provider/pkg/provider/local/commandController.go
@@ -115,7 +115,7 @@ func (r *Command) WireDependencies(f infer.FieldSelector, args *CommandInputs, s
 
 // The Update method will be run on every update.
 func (c *Command) Update(ctx p.Context, id string, olds CommandOutputs, news CommandInputs, preview bool) (CommandOutputs, error) {
-	state := CommandOutputs{CommandInputs: news}
+	state := CommandOutputs{CommandInputs: news, BaseOutputs: olds.BaseOutputs}
 	// If in preview, don't run the command.
 	if preview {
 		return state, nil

--- a/provider/pkg/provider/remote/commandController.go
+++ b/provider/pkg/provider/remote/commandController.go
@@ -82,7 +82,7 @@ func (*Command) Create(ctx p.Context, name string, input CommandInputs, preview 
 
 // The Update method will be run on every update.
 func (*Command) Update(ctx p.Context, id string, olds CommandOutputs, news CommandInputs, preview bool) (CommandOutputs, error) {
-	state := CommandOutputs{CommandInputs: news}
+	state := CommandOutputs{CommandInputs: news, BaseOutputs: olds.BaseOutputs}
 	if preview {
 		return state, nil
 	}


### PR DESCRIPTION
This PR fixes this issue: https://github.com/pulumi/pulumi-command/issues/190

In the Update method, the `news` input struct contains Triggers, Create, Update, and Delete fields, while the `olds` output struct contains Stdout, Stderr, Assets, and Archive fields.

The state variable in the Update method only contains `news` input, causing empty stdout and stderr in downstream code https://github.com/pulumi/pulumi-command/blob/master/provider/pkg/provider/local/commandOutputs.go#L71

We can fix this by merging the `news` and `olds` inputs and outputs into a new CommandOutputs struct. The result is a new CommandOutputs struct that contains all the fields from both the CommandInputs and BaseOutputs structs. If any fields are present in both structs, the value from news will take precedence over the value from olds.
