### PR TITLE
Regenerate SDKs

### DIFF
--- a/sdk/dotnet/Pulumi.Command.csproj
+++ b/sdk/dotnet/Pulumi.Command.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-command</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -48,12 +48,12 @@ dependencies {
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
-    classifier = 'sources'
+    archiveClassifier.set('sources')
 }
 
 task javadocJar(type: Jar) {
     from javadoc
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
 }
 
 def genPulumiResources = tasks.register('genPulumiResources') {


### PR DESCRIPTION
We depend on the latest version of Pulumi for codegen. We also require that running `make build` produces zero diffs on PRs. This is great... except when Pulumi changes the output of `make codegen`. This PR brings our checked in SDKs back into alignment with what `make build` is generating.