### PR TITLE
Copy logo asset before running `dotnet build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,12 @@ dotnet_sdk:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 dotnet_sdk::
 	rm -rf sdk/dotnet
 	pulumi package gen-sdk --language dotnet $(SCHEMA_FILE)
+	# Copy the logo to the dotnet directory before building so it can be included in the nuget package archive.
+	# https://github.com/pulumi/pulumi-command/issues/243
 	cd ${PACKDIR}/dotnet/&& \
 		echo "${DOTNET_VERSION}" >version.txt && \
+		cp $(WORKING_DIR)/assets/logo.png logo.png && \
 		dotnet build /p:Version=${DOTNET_VERSION}
-# Work around for https://github.com/pulumi/pulumi/issues/13589
-	cp assets/logo.png ${PACKDIR}/dotnet/logo.png
 
 go_sdk::
 	rm -rf sdk/go


### PR DESCRIPTION
Fixes: #243 

The nuget publishing failure occurs due to us copying the logo asset after creating the `/sdk/dotnet/bin/Debug/Pulumi.*.nupkg` file. This is the nuget archive that we push to the API, so we'll need to copy the logo asset before creating the archive.