### PR TITLE
Fix stdout and stderr on run command

### DIFF
--- a/provider/pkg/provider/local/commandController.go
+++ b/provider/pkg/provider/local/commandController.go
@@ -31,7 +31,8 @@ var _ = (infer.ExplicitDependencies[CommandInputs, CommandOutputs])((*Command)(n
 
 // This is the Create method. This will be run on every Command resource creation.
 func (c *Command) Create(ctx p.Context, name string, input CommandInputs, preview bool) (string, CommandOutputs, error) {
-	state := CommandOutputs{CommandInputs: input}
+	outputs := BaseOutputs{Stdout: *input.Stdin, Stderr: *input.Stdin}
+	state := CommandOutputs{CommandInputs: input, BaseOutputs: outputs}
 	id, err := resource.NewUniqueHex(name, 8, 0)
 	if err != nil {
 		return id, state, err


### PR DESCRIPTION
Mimics https://github.com/pulumi/pulumi-command/pull/191/files but on create, so `stdout` + `stderr` is emitted on the initial create as well as subsequent updates


Fixes https://github.com/pulumi/pulumi-command/issues/198