### PR TITLE
Fix pinning ambient plugins to solve for possible code drift better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ WORKING_DIR     := $(shell pwd)
 TESTPARALLELISM := 4
 
 # Need to pick up locally pinned pulumi-langage-* plugins.
-export PATH := .pulumi/bin:$(PATH)
+export PULUMI_IGNORE_AMBIENT_PLUGINS = true
 
 ensure:: tidy
 


### PR DESCRIPTION
Per @danielrbradley this is the solution from azure-native that works just as well.