### PR TITLE
Don't swallow Setenv error and add guidance to docs

### DIFF
--- a/examples/ec2_remote/index.ts
+++ b/examples/ec2_remote/index.ts
@@ -61,9 +61,6 @@ const poll = new remote.Command("poll", {
 const hostname = new remote.Command("hostname", {
     connection,
     create: "hostname",
-    environment: secret({
-      "secret-key": secret("super-secret-value")
-    }),
 }, { dependsOn: poll });
 
 new remote.Command("remotePrivateIP", {
@@ -95,7 +92,6 @@ const catSize = new remote.Command("checkSize", {
 }, { dependsOn: sizeFile })
 
 export const connectionSecret = hostname.connection;
-export const secretEnv = hostname.environment;
 export const confirmSize = catSize.stdout;
 export const publicIp = server.publicIp;
 export const publicHostName = server.publicDns;

--- a/examples/ec2_remote_proxy/index.ts
+++ b/examples/ec2_remote_proxy/index.ts
@@ -77,9 +77,6 @@ const hostname = new remote.Command("hostname", {
         }
     },
     create: "hostname",
-    environment: secret({
-        "secret-key": secret("super-secret-value")
-    }),
 }, { customTimeouts: { create: "10m" } });
 
 new remote.Command("remotePrivateIP", {
@@ -105,7 +102,6 @@ const catSize = new remote.Command("checkSize", {
 }, { dependsOn: sizeFile })
 
 export const connectionSecret = hostname.connection;
-export const secretEnv = hostname.environment;
 export const confirmSize = catSize.stdout;
 export const publicIp = server.publicIp;
 export const publicHostName = server.publicDns;

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -225,7 +225,6 @@ func testEc2Ts(t *testing.T, targetDir string) {
 					assert.Truef(t, isEncrypted(m[key]), "%s value should be encrypted", key)
 				}
 				assertEncryptedValue(stack.Outputs, "connectionSecret")
-				assertEncryptedValue(stack.Outputs, "secretEnv")
 			},
 		})
 

--- a/provider/cmd/pulumi-resource-command/schema.json
+++ b/provider/cmd/pulumi-resource-command/schema.json
@@ -332,7 +332,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Additional environment variables available to the command's process."
+          "description": "Additional environment variables available to the command's process.\nNote that this only works if the SSH server is configured to accept these variables via AcceptEnv.\nAlternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself\nwith the variables in the form 'VAR=value command'."
         },
         "stderr": {
           "type": "string",
@@ -384,7 +384,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Additional environment variables available to the command's process."
+          "description": "Additional environment variables available to the command's process.\nNote that this only works if the SSH server is configured to accept these variables via AcceptEnv.\nAlternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself\nwith the variables in the form 'VAR=value command'."
         },
         "stdin": {
           "type": "string",

--- a/provider/pkg/provider/remote/command.go
+++ b/provider/pkg/provider/remote/command.go
@@ -47,7 +47,10 @@ type CommandInputs struct {
 // be visible in the provider's schema and the generated SDKs.
 func (c *CommandInputs) Annotate(a infer.Annotator) {
 	a.Describe(&c.Connection, "The parameters with which to connect to the remote host.")
-	a.Describe(&c.Environment, "Additional environment variables available to the command's process.")
+	a.Describe(&c.Environment, `Additional environment variables available to the command's process.
+Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+with the variables in the form 'VAR=value command'.`)
 	a.Describe(&c.Triggers, "Trigger replacements on changes to this input.")
 	a.Describe(&c.Create, "The command to run on create.")
 	a.Describe(&c.Delete, `The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT

--- a/provider/pkg/provider/remote/command.go
+++ b/provider/pkg/provider/remote/command.go
@@ -34,13 +34,13 @@ type CommandInputs struct {
 	// pulumi:"optional" specifies that a field is optional. This must be a pointer.
 	// provider:"replaceOnChanges" specifies that the resource will be replaced if the field changes.
 	// provider:"secret" specifies that a field should be marked secret.
-	Connection  *Connection        `pulumi:"connection" provider:"secret"`
-	Environment *map[string]string `pulumi:"environment,optional"`
-	Triggers    *[]any             `pulumi:"triggers,optional" provider:"replaceOnChanges"`
-	Create      *string            `pulumi:"create,optional"`
-	Delete      *string            `pulumi:"delete,optional"`
-	Update      *string            `pulumi:"update,optional"`
-	Stdin       *string            `pulumi:"stdin,optional"`
+	Connection  *Connection       `pulumi:"connection" provider:"secret"`
+	Environment map[string]string `pulumi:"environment,optional"`
+	Triggers    *[]any            `pulumi:"triggers,optional" provider:"replaceOnChanges"`
+	Create      *string           `pulumi:"create,optional"`
+	Delete      *string           `pulumi:"delete,optional"`
+	Update      *string           `pulumi:"update,optional"`
+	Stdin       *string           `pulumi:"stdin,optional"`
 }
 
 // Implementing Annotate lets you provide descriptions and default values for arguments and they will

--- a/provider/pkg/provider/remote/commandOutputs.go
+++ b/provider/pkg/provider/remote/commandOutputs.go
@@ -39,10 +39,13 @@ func (c *CommandOutputs) run(ctx p.Context, cmd string) error {
 	defer session.Close()
 
 	if c.Environment != nil {
-		for k, v := range *c.Environment {
+		for k, v := range c.Environment {
 			err := session.Setenv(k, v)
 			if err != nil {
-				return fmt.Errorf("could not set environment variable '%s': %w. Please see the `environment` property's documentation for guidance", k, err)
+				ctx.Logf(diag.Error, `Unable to set '%s'. This only works if your SSH server is configured to accept
+ these variables via AcceptEnv. Alternatively, if a Bash-like shell runs the command on the remote host, you could
+ prefix the command itself with the variables in the form 'VAR=value command'`, k)
+				return fmt.Errorf("could not set environment variable '%s': %w", k, err)
 			}
 		}
 	}

--- a/provider/pkg/provider/remote/commandOutputs.go
+++ b/provider/pkg/provider/remote/commandOutputs.go
@@ -40,7 +40,10 @@ func (c *CommandOutputs) run(ctx p.Context, cmd string) error {
 
 	if c.Environment != nil {
 		for k, v := range *c.Environment {
-			session.Setenv(k, v)
+			err := session.Setenv(k, v)
+			if err != nil {
+				return fmt.Errorf("could not set environment variable '%s': %w. Please see the `environment` property's documentation for guidance", k, err)
+			}
 		}
 	}
 	if c.Stdout != "" {

--- a/sdk/dotnet/Remote/Command.cs
+++ b/sdk/dotnet/Remote/Command.cs
@@ -38,6 +38,9 @@ namespace Pulumi.Command.Remote
 
         /// <summary>
         /// Additional environment variables available to the command's process.
+        /// Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+        /// Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+        /// with the variables in the form 'VAR=value command'.
         /// </summary>
         [Output("environment")]
         public Output<ImmutableDictionary<string, string>?> Environment { get; private set; } = null!;
@@ -163,6 +166,9 @@ namespace Pulumi.Command.Remote
 
         /// <summary>
         /// Additional environment variables available to the command's process.
+        /// Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+        /// Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+        /// with the variables in the form 'VAR=value command'.
         /// </summary>
         public InputMap<string> Environment
         {

--- a/sdk/go/command/remote/command.go
+++ b/sdk/go/command/remote/command.go
@@ -26,6 +26,9 @@ type Command struct {
 	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrOutput `pulumi:"delete"`
 	// Additional environment variables available to the command's process.
+	// Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+	// Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+	// with the variables in the form 'VAR=value command'.
 	Environment pulumi.StringMapOutput `pulumi:"environment"`
 	// The standard error of the command's process
 	Stderr pulumi.StringOutput `pulumi:"stderr"`
@@ -106,6 +109,9 @@ type commandArgs struct {
 	// Command resource from previous create or update steps.
 	Delete *string `pulumi:"delete"`
 	// Additional environment variables available to the command's process.
+	// Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+	// Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+	// with the variables in the form 'VAR=value command'.
 	Environment map[string]string `pulumi:"environment"`
 	// Pass a string to the command's process as standard in
 	Stdin *string `pulumi:"stdin"`
@@ -129,6 +135,9 @@ type CommandArgs struct {
 	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrInput
 	// Additional environment variables available to the command's process.
+	// Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+	// Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+	// with the variables in the form 'VAR=value command'.
 	Environment pulumi.StringMapInput
 	// Pass a string to the command's process as standard in
 	Stdin pulumi.StringPtrInput
@@ -246,6 +255,9 @@ func (o CommandOutput) Delete() pulumi.StringPtrOutput {
 }
 
 // Additional environment variables available to the command's process.
+// Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+// Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+// with the variables in the form 'VAR=value command'.
 func (o CommandOutput) Environment() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Command) pulumi.StringMapOutput { return v.Environment }).(pulumi.StringMapOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/command/remote/Command.java
+++ b/sdk/java/src/main/java/com/pulumi/command/remote/Command.java
@@ -72,6 +72,9 @@ public class Command extends com.pulumi.resources.CustomResource {
     }
     /**
      * Additional environment variables available to the command&#39;s process.
+     * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+     * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+     * with the variables in the form &#39;VAR=value command&#39;.
      * 
      */
     @Export(name="environment", refs={Map.class,String.class}, tree="[0,1,1]")
@@ -79,6 +82,9 @@ public class Command extends com.pulumi.resources.CustomResource {
 
     /**
      * @return Additional environment variables available to the command&#39;s process.
+     * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+     * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+     * with the variables in the form &#39;VAR=value command&#39;.
      * 
      */
     public Output<Optional<Map<String,String>>> environment() {

--- a/sdk/java/src/main/java/com/pulumi/command/remote/CommandArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/command/remote/CommandArgs.java
@@ -71,6 +71,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * Additional environment variables available to the command&#39;s process.
+     * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+     * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+     * with the variables in the form &#39;VAR=value command&#39;.
      * 
      */
     @Import(name="environment")
@@ -78,6 +81,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * @return Additional environment variables available to the command&#39;s process.
+     * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+     * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+     * with the variables in the form &#39;VAR=value command&#39;.
      * 
      */
     public Optional<Output<Map<String,String>>> environment() {
@@ -234,6 +240,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param environment Additional environment variables available to the command&#39;s process.
+         * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+         * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+         * with the variables in the form &#39;VAR=value command&#39;.
          * 
          * @return builder
          * 
@@ -245,6 +254,9 @@ public final class CommandArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param environment Additional environment variables available to the command&#39;s process.
+         * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+         * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+         * with the variables in the form &#39;VAR=value command&#39;.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/remote/command.ts
+++ b/sdk/nodejs/remote/command.ts
@@ -53,6 +53,9 @@ export class Command extends pulumi.CustomResource {
     public readonly delete!: pulumi.Output<string | undefined>;
     /**
      * Additional environment variables available to the command's process.
+     * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+     * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+     * with the variables in the form 'VAR=value command'.
      */
     public readonly environment!: pulumi.Output<{[key: string]: string} | undefined>;
     /**
@@ -142,6 +145,9 @@ export interface CommandArgs {
     delete?: pulumi.Input<string>;
     /**
      * Additional environment variables available to the command's process.
+     * Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+     * Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+     * with the variables in the form 'VAR=value command'.
      */
     environment?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**

--- a/sdk/python/pulumi_command/remote/command.py
+++ b/sdk/python/pulumi_command/remote/command.py
@@ -31,6 +31,9 @@ class CommandArgs:
                and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
                Command resource from previous create or update steps.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
+               Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+               Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+               with the variables in the form 'VAR=value command'.
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
         :param pulumi.Input[str] update: The command to run on update, if empty, create will 
@@ -95,6 +98,9 @@ class CommandArgs:
     def environment(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
         Additional environment variables available to the command's process.
+        Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+        Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+        with the variables in the form 'VAR=value command'.
         """
         return pulumi.get(self, "environment")
 
@@ -167,6 +173,9 @@ class Command(pulumi.CustomResource):
                and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
                Command resource from previous create or update steps.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] environment: Additional environment variables available to the command's process.
+               Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+               Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+               with the variables in the form 'VAR=value command'.
         :param pulumi.Input[str] stdin: Pass a string to the command's process as standard in
         :param pulumi.Input[Sequence[Any]] triggers: Trigger replacements on changes to this input.
         :param pulumi.Input[str] update: The command to run on update, if empty, create will 
@@ -294,6 +303,9 @@ class Command(pulumi.CustomResource):
     def environment(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
         """
         Additional environment variables available to the command's process.
+        Note that this only works if the SSH server is configured to accept these variables via AcceptEnv.
+        Alternatively, if a Bash-like shell runs the command on the remote host, you could prefix the command itself
+        with the variables in the form 'VAR=value command'.
         """
         return pulumi.get(self, "environment")
 


### PR DESCRIPTION
Resolves #48 

Address the issue that the `environment` property was seemingly ignored for remote commands.

First, don't ignore the Go error from `Setenv`.

Second, document the situation a bit better. It's complex since it depends on OS, remote shell, and SSH configuration, but hopefully we can give some additional pointers for further research.