### PR TITLE
Export GOPATH to preserve it when called from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION_PATH    := ${PROVIDER_PATH}/pkg/version.Version
 PULUMI          := .pulumi/bin/pulumi
 
 SCHEMA_FILE     := provider/cmd/pulumi-resource-command/schema.json
-GOPATH          := $(shell go env GOPATH)
+export GOPATH   := $(shell go env GOPATH)
 
 WORKING_DIR     := $(shell pwd)
 TESTPARALLELISM := 4


### PR DESCRIPTION
This is a follow-up to #392. Without the export, in some cases `go` gets lost and creates a new modcache in the local directory, i.e., the repository.