### PR TITLE
Bump wait time for EC2 instance due to occasional test failures

### DIFF
--- a/examples/ec2_remote/index.ts
+++ b/examples/ec2_remote/index.ts
@@ -56,7 +56,7 @@ const connectionNoDialRetry: types.input.remote.ConnectionArgs = {
 const poll = new remote.Command("poll", {
   connection: { ...connection, dialErrorLimit: -1 },
     create: "echo 'Connection established'",
-}, { customTimeouts: { create: "10m" } })
+}, { customTimeouts: { create: "12m" } })
 
 const hostname = new remote.Command("hostname", {
     connection,

--- a/examples/ec2_remote_proxy/index.ts
+++ b/examples/ec2_remote_proxy/index.ts
@@ -77,7 +77,7 @@ const hostname = new remote.Command("hostname", {
         }
     },
     create: "hostname",
-}, { customTimeouts: { create: "10m" } });
+}, { customTimeouts: { create: "12m" } });
 
 new remote.Command("remotePrivateIP", {
     connection,


### PR DESCRIPTION
[Example of a timeout failure](https://github.com/pulumi/pulumi-command/actions/runs/8892804234/job/24417764421?pr=414). Try improving test suite reliability by waiting a bit longer for EC2.