### PR TITLE
upgrade pulumi-go-provider to the latest versions

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gliderlabs/ssh v0.3.7
 	github.com/gobwas/glob v0.2.3
 	github.com/pkg/sftp v1.13.4
-	github.com/pulumi/pulumi-go-provider v0.13.1-0.20231204212757-ab334266917c
+	github.com/pulumi/pulumi-go-provider v0.17.0
 	github.com/pulumi/pulumi/sdk/v3 v3.115.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.22.0
@@ -90,13 +90,13 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -162,8 +162,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.6.2 h1:+z+l8cuwIauLSwXQS0uoI3rqB+YG4SzsZYtHfNoXBvw=
 github.com/pulumi/esc v0.6.2/go.mod h1:jNnYNjzsOgVTjCp0LL24NsCk8ZJxq4IoLQdCT0X7l8k=
-github.com/pulumi/pulumi-go-provider v0.13.1-0.20231204212757-ab334266917c h1:CU9nHdWg4GhN9bVVNVd5T6n5YIuMDb2ACHsIYon1IXI=
-github.com/pulumi/pulumi-go-provider v0.13.1-0.20231204212757-ab334266917c/go.mod h1:+2ZJDPOzZ97nFH2aJAQrH7zOmMrRWYKuA47LuVWhmIc=
+github.com/pulumi/pulumi-go-provider v0.17.0 h1:fGRUStT3xUmoxTpwLXwFW5DjvGqs767YfdzGAISPvYY=
+github.com/pulumi/pulumi-go-provider v0.17.0/go.mod h1:MRDwRZQCO/ThTSO2InDLN8WKSB3VyYfgl9jM9s87In0=
 github.com/pulumi/pulumi/pkg/v3 v3.115.2 h1:lMpGc/pSAsSz4ZE4IRi1/XYWzyZQpjy0OJ4TNcMIr+k=
 github.com/pulumi/pulumi/pkg/v3 v3.115.2/go.mod h1:Sbl1hEyTXpc1Yu2GbKU6h3rWyuUkrTAzTZ+MioYOZl8=
 github.com/pulumi/pulumi/sdk/v3 v3.115.2 h1:CFx/KfS3fsp2EiXnX70JNUBvHADNqiQ617AVslu5I6E=
@@ -251,8 +251,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
+golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -314,8 +314,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7 h1:8EeVk1VKMD+GD/neyEHGmz7pFblqPjHoi+PGQIlLx2s=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be h1:LG9vZxsWGOmUKieR8wPAUR3u3MpnYFQZROPIMaXh7/A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=

--- a/provider/pkg/provider/local/commandController.go
+++ b/provider/pkg/provider/local/commandController.go
@@ -15,7 +15,8 @@
 package local
 
 import (
-	p "github.com/pulumi/pulumi-go-provider"
+	"context"
+
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -24,12 +25,14 @@ import (
 // If the function signature doesn't match or isn't implemented, we get nice compile time errors at this location.
 
 // They would normally be included in the commandController.go file, but they're located here for instructive purposes.
-var _ = (infer.CustomResource[CommandInputs, CommandOutputs])((*Command)(nil))
-var _ = (infer.CustomUpdate[CommandInputs, CommandOutputs])((*Command)(nil))
-var _ = (infer.CustomDelete[CommandOutputs])((*Command)(nil))
+var (
+	_ = (infer.CustomResource[CommandInputs, CommandOutputs])((*Command)(nil))
+	_ = (infer.CustomUpdate[CommandInputs, CommandOutputs])((*Command)(nil))
+	_ = (infer.CustomDelete[CommandOutputs])((*Command)(nil))
+)
 
 // This is the Create method. This will be run on every Command resource creation.
-func (c *Command) Create(ctx p.Context, name string, input CommandInputs, preview bool) (string, CommandOutputs, error) {
+func (c *Command) Create(ctx context.Context, name string, input CommandInputs, preview bool) (string, CommandOutputs, error) {
 	state := CommandOutputs{CommandInputs: input}
 	id, err := resource.NewUniqueHex(name, 8, 0)
 	if err != nil {
@@ -56,7 +59,7 @@ func (c *Command) Create(ctx p.Context, name string, input CommandInputs, previe
 // Because we want every output to depend on every input, we can leave the default behavior.
 
 // The Update method will be run on every update.
-func (c *Command) Update(ctx p.Context, id string, olds CommandOutputs, news CommandInputs, preview bool) (CommandOutputs, error) {
+func (c *Command) Update(ctx context.Context, id string, olds CommandOutputs, news CommandInputs, preview bool) (CommandOutputs, error) {
 	state := CommandOutputs{CommandInputs: news, BaseOutputs: olds.BaseOutputs}
 	// If in preview, don't run the command.
 	if preview {
@@ -76,7 +79,7 @@ func (c *Command) Update(ctx p.Context, id string, olds CommandOutputs, news Com
 }
 
 // The Delete method will run when the resource is deleted.
-func (c *Command) Delete(ctx p.Context, id string, props CommandOutputs) error {
+func (c *Command) Delete(ctx context.Context, id string, props CommandOutputs) error {
 	if props.Delete == nil {
 		return nil
 	}

--- a/provider/pkg/provider/local/commandOutputs.go
+++ b/provider/pkg/provider/local/commandOutputs.go
@@ -16,6 +16,7 @@ package local
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -26,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/gobwas/glob"
-	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -35,7 +35,7 @@ import (
 	"github.com/pulumi/pulumi-command/provider/pkg/provider/util"
 )
 
-func run(ctx p.Context, command string, in BaseInputs, out *BaseOutputs, logging *common.Logging) error {
+func run(ctx context.Context, command string, in BaseInputs, out *BaseOutputs, logging *common.Logging) error {
 	contract.Assertf(out != nil, "run:out cannot be nil")
 	var args []string
 	if in.Interpreter != nil && len(*in.Interpreter) > 0 {

--- a/provider/pkg/provider/local/runController.go
+++ b/provider/pkg/provider/local/runController.go
@@ -14,11 +14,11 @@
 
 package local
 
-import p "github.com/pulumi/pulumi-go-provider"
+import "context"
 
 // This is the Call method. It takes a RunInputs parameter and runs the command specified in
 // it.
-func (*Run) Call(ctx p.Context, input RunInputs) (RunOutputs, error) {
+func (*Run) Call(ctx context.Context, input RunInputs) (RunOutputs, error) {
 	r := RunOutputs{RunInputs: input}
 	err := run(ctx, input.Command, r.RunInputs.BaseInputs, &r.BaseOutputs, input.Logging)
 	return r, err

--- a/provider/pkg/provider/remote/commandController.go
+++ b/provider/pkg/provider/remote/commandController.go
@@ -15,19 +15,22 @@
 package remote
 
 import (
-	p "github.com/pulumi/pulumi-go-provider"
+	"context"
+
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 // These are not required. They indicate to Go that Command implements the following interfaces.
 // If the function signature doesn't match or isn't implemented, we get nice compile time errors in this file.
-var _ = (infer.CustomResource[CommandInputs, CommandOutputs])((*Command)(nil))
-var _ = (infer.CustomUpdate[CommandInputs, CommandOutputs])((*Command)(nil))
-var _ = (infer.CustomDelete[CommandOutputs])((*Command)(nil))
+var (
+	_ = (infer.CustomResource[CommandInputs, CommandOutputs])((*Command)(nil))
+	_ = (infer.CustomUpdate[CommandInputs, CommandOutputs])((*Command)(nil))
+	_ = (infer.CustomDelete[CommandOutputs])((*Command)(nil))
+)
 
 // This is the Create method. This will be run on every Command resource creation.
-func (*Command) Create(ctx p.Context, name string, input CommandInputs, preview bool) (string, CommandOutputs, error) {
+func (*Command) Create(ctx context.Context, name string, input CommandInputs, preview bool) (string, CommandOutputs, error) {
 	state := CommandOutputs{CommandInputs: input}
 	var err error
 	id, err := resource.NewUniqueHex(name, 8, 0)
@@ -53,7 +56,7 @@ func (*Command) Create(ctx p.Context, name string, input CommandInputs, preview 
 }
 
 // The Update method will be run on every update.
-func (*Command) Update(ctx p.Context, id string, olds CommandOutputs, news CommandInputs, preview bool) (CommandOutputs, error) {
+func (*Command) Update(ctx context.Context, id string, olds CommandOutputs, news CommandInputs, preview bool) (CommandOutputs, error) {
 	state := CommandOutputs{CommandInputs: news, BaseOutputs: olds.BaseOutputs}
 	if preview {
 		return state, nil
@@ -70,7 +73,7 @@ func (*Command) Update(ctx p.Context, id string, olds CommandOutputs, news Comma
 }
 
 // The Delete method will run when the resource is deleted.
-func (*Command) Delete(ctx p.Context, id string, props CommandOutputs) error {
+func (*Command) Delete(ctx context.Context, id string, props CommandOutputs) error {
 	if props.Delete == nil {
 		return nil
 	}

--- a/provider/pkg/provider/remote/copyfileController.go
+++ b/provider/pkg/provider/remote/copyfileController.go
@@ -15,13 +15,13 @@
 package remote
 
 import (
+	"context"
 	"os"
 
 	"github.com/pkg/sftp"
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -30,12 +30,13 @@ import (
 var _ = (infer.CustomResource[CopyFileInputs, CopyFileOutputs])((*CopyFile)(nil))
 
 // This is the Create method. This will be run on every CopyFile resource creation.
-func (*CopyFile) Create(ctx p.Context, name string, input CopyFileInputs, preview bool) (string, CopyFileOutputs, error) {
+func (*CopyFile) Create(ctx context.Context, name string, input CopyFileInputs, preview bool) (string, CopyFileOutputs, error) {
 	if preview {
 		return "", CopyFileOutputs{input}, nil
 	}
 
-	ctx.Logf(diag.Debug,
+	logger := p.GetLogger(ctx)
+	logger.Debugf(
 		"Creating file: %s:%s from local file %s",
 		input.Connection.Host, input.RemotePath, input.LocalPath)
 

--- a/provider/pkg/provider/util/testutil/testutil.go
+++ b/provider/pkg/provider/util/testutil/testutil.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 )
 
-// TestContext is an implementation of p.Context that records all log messages in a buffer, regardless of severity.
+// TestContext is an implementation of context.Context that records all log messages in a buffer, regardless of severity.
 type TestContext struct {
 	context.Context
 	Output bytes.Buffer

--- a/provider/pkg/provider/util/util.go
+++ b/provider/pkg/provider/util/util.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"sync"
 
@@ -23,14 +24,26 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 )
 
-const PULUMI_COMMAND_STDOUT = "PULUMI_COMMAND_STDOUT"
-const PULUMI_COMMAND_STDERR = "PULUMI_COMMAND_STDERR"
+const (
+	PULUMI_COMMAND_STDOUT = "PULUMI_COMMAND_STDOUT"
+	PULUMI_COMMAND_STDERR = "PULUMI_COMMAND_STDERR"
+)
 
-func LogOutput(ctx p.Context, r io.Reader, doneCh chan<- struct{}, severity diag.Severity) {
+func LogOutput(ctx context.Context, r io.Reader, doneCh chan<- struct{}, severity diag.Severity) {
 	defer close(doneCh)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		ctx.LogStatus(severity, scanner.Text())
+		logger := p.GetLogger(ctx)
+		switch severity {
+		case diag.Debug:
+			logger.DebugStatus(scanner.Text())
+		case diag.Info:
+			logger.InfoStatus(scanner.Text())
+		case diag.Warning:
+			logger.WarningStatus(scanner.Text())
+		case diag.Error:
+			logger.ErrorStatus(scanner.Text())
+		}
 	}
 }
 

--- a/provider/tests/go.mod
+++ b/provider/tests/go.mod
@@ -7,8 +7,7 @@ replace github.com/pulumi/pulumi-command/provider => ../
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pulumi/pulumi-command/provider v0.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi-go-provider v0.13.1-0.20231204212757-ab334266917c
-	github.com/pulumi/pulumi-go-provider/integration v0.10.1-0.20231204212757-ab334266917c
+	github.com/pulumi/pulumi-go-provider v0.17.0
 	github.com/pulumi/pulumi/sdk/v3 v3.115.2
 	github.com/stretchr/testify v1.9.0
 )
@@ -92,13 +91,13 @@ require (
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/provider/tests/go.sum
+++ b/provider/tests/go.sum
@@ -162,10 +162,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.6.2 h1:+z+l8cuwIauLSwXQS0uoI3rqB+YG4SzsZYtHfNoXBvw=
 github.com/pulumi/esc v0.6.2/go.mod h1:jNnYNjzsOgVTjCp0LL24NsCk8ZJxq4IoLQdCT0X7l8k=
-github.com/pulumi/pulumi-go-provider v0.13.1-0.20231204212757-ab334266917c h1:CU9nHdWg4GhN9bVVNVd5T6n5YIuMDb2ACHsIYon1IXI=
-github.com/pulumi/pulumi-go-provider v0.13.1-0.20231204212757-ab334266917c/go.mod h1:+2ZJDPOzZ97nFH2aJAQrH7zOmMrRWYKuA47LuVWhmIc=
-github.com/pulumi/pulumi-go-provider/integration v0.10.1-0.20231204212757-ab334266917c h1:lsm2+SujuDeeXN7Om59bCsrLyWIL8ILKpUMLESmJyCM=
-github.com/pulumi/pulumi-go-provider/integration v0.10.1-0.20231204212757-ab334266917c/go.mod h1:Sxkgzi2ZLFo+jbX2hx9qMAoxWJ0dzORS8XkZehqnRd4=
+github.com/pulumi/pulumi-go-provider v0.17.0 h1:fGRUStT3xUmoxTpwLXwFW5DjvGqs767YfdzGAISPvYY=
+github.com/pulumi/pulumi-go-provider v0.17.0/go.mod h1:MRDwRZQCO/ThTSO2InDLN8WKSB3VyYfgl9jM9s87In0=
 github.com/pulumi/pulumi/pkg/v3 v3.115.2 h1:lMpGc/pSAsSz4ZE4IRi1/XYWzyZQpjy0OJ4TNcMIr+k=
 github.com/pulumi/pulumi/pkg/v3 v3.115.2/go.mod h1:Sbl1hEyTXpc1Yu2GbKU6h3rWyuUkrTAzTZ+MioYOZl8=
 github.com/pulumi/pulumi/sdk/v3 v3.115.2 h1:CFx/KfS3fsp2EiXnX70JNUBvHADNqiQ617AVslu5I6E=
@@ -253,8 +251,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
+golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -316,8 +314,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7 h1:8EeVk1VKMD+GD/neyEHGmz7pFblqPjHoi+PGQIlLx2s=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240311173647-c811ad7063a7/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be h1:LG9vZxsWGOmUKieR8wPAUR3u3MpnYFQZROPIMaXh7/A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=


### PR DESCRIPTION
Upgrade the pulumi-go-provider to the latest version, as the latest version fixes a potential panic.

Fixes https://github.com/pulumi/pulumi-command/issues/435