### PR TITLE
Correct struct tag and property name of Triggers replace annotation

### DIFF
--- a/provider/cmd/pulumi-resource-command/schema.json
+++ b/provider/cmd/pulumi-resource-command/schema.json
@@ -103,7 +103,7 @@
         },
         "port": {
           "type": "number",
-          "description": "The port to connect to.",
+          "description": "The port to connect to. Defaults to 22.",
           "default": 22
         },
         "privateKey": {
@@ -490,7 +490,8 @@
           "items": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Trigger replacements on changes to this input."
+          "description": "Trigger replacements on changes to this input.",
+          "replaceOnChanges": true
         }
       },
       "type": "object",
@@ -518,7 +519,8 @@
           "items": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Trigger replacements on changes to this input."
+          "description": "Trigger replacements on changes to this input.",
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [

--- a/provider/pkg/provider/remote/connection.go
+++ b/provider/pkg/provider/remote/connection.go
@@ -60,7 +60,7 @@ func (c *Connection) Annotate(a infer.Annotator) {
 	a.SetDefault(&c.User, "root")
 	a.Describe(&c.Password, "The password we should use for the connection.")
 	a.Describe(&c.Host, "The address of the resource to connect to.")
-	a.Describe(&c.Port, "The port to connect to.")
+	a.Describe(&c.Port, "The port to connect to. Defaults to 22.")
 	a.SetDefault(&c.Port, 22)
 	a.Describe(&c.PrivateKey, "The contents of an SSH key to use for the connection. This takes preference over the password if provided.")
 	a.Describe(&c.PrivateKeyPassword, "The password to use in case the private key is encrypted.")

--- a/provider/pkg/provider/remote/copyfile.go
+++ b/provider/pkg/provider/remote/copyfile.go
@@ -29,7 +29,7 @@ func (c *CopyFile) Annotate(a infer.Annotator) {
 
 type CopyFileInputs struct {
 	Connection *Connection    `pulumi:"connection" provider:"secret"`
-	Triggers   *[]interface{} `pulumi:"triggers,optional" providers:"replaceOnDelete"`
+	Triggers   *[]interface{} `pulumi:"triggers,optional" provider:"replaceOnChanges"`
 	LocalPath  string         `pulumi:"localPath"`
 	RemotePath string         `pulumi:"remotePath"`
 }

--- a/sdk/dotnet/Remote/CopyFile.cs
+++ b/sdk/dotnet/Remote/CopyFile.cs
@@ -66,6 +66,10 @@ namespace Pulumi.Command.Remote
                 {
                     "connection",
                 },
+                ReplaceOnChanges =
+                {
+                    "triggers[*]",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/Remote/Inputs/ConnectionArgs.cs
+++ b/sdk/dotnet/Remote/Inputs/ConnectionArgs.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Command.Remote.Inputs
         public Input<int>? PerDialTimeout { get; set; }
 
         /// <summary>
-        /// The port to connect to.
+        /// The port to connect to. Defaults to 22.
         /// </summary>
         [Input("port")]
         public Input<double>? Port { get; set; }

--- a/sdk/dotnet/Remote/Outputs/Connection.cs
+++ b/sdk/dotnet/Remote/Outputs/Connection.cs
@@ -37,7 +37,7 @@ namespace Pulumi.Command.Remote.Outputs
         /// </summary>
         public readonly int? PerDialTimeout;
         /// <summary>
-        /// The port to connect to.
+        /// The port to connect to. Defaults to 22.
         /// </summary>
         public readonly double? Port;
         /// <summary>

--- a/sdk/go/command/remote/copyFile.go
+++ b/sdk/go/command/remote/copyFile.go
@@ -50,6 +50,10 @@ func NewCopyFile(ctx *pulumi.Context,
 		"connection",
 	})
 	opts = append(opts, secrets)
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"triggers[*]",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource CopyFile
 	err := ctx.RegisterResource("command:remote:CopyFile", name, args, &resource, opts...)

--- a/sdk/go/command/remote/pulumiTypes.go
+++ b/sdk/go/command/remote/pulumiTypes.go
@@ -25,7 +25,7 @@ type Connection struct {
 	Password *string `pulumi:"password"`
 	// Max number of seconds for each dial attempt. 0 implies no maximum. Default value is 15 seconds.
 	PerDialTimeout *int `pulumi:"perDialTimeout"`
-	// The port to connect to.
+	// The port to connect to. Defaults to 22.
 	Port *float64 `pulumi:"port"`
 	// The contents of an SSH key to use for the connection. This takes preference over the password if provided.
 	PrivateKey *string `pulumi:"privateKey"`
@@ -87,7 +87,7 @@ type ConnectionArgs struct {
 	Password pulumi.StringPtrInput `pulumi:"password"`
 	// Max number of seconds for each dial attempt. 0 implies no maximum. Default value is 15 seconds.
 	PerDialTimeout pulumi.IntPtrInput `pulumi:"perDialTimeout"`
-	// The port to connect to.
+	// The port to connect to. Defaults to 22.
 	Port pulumi.Float64PtrInput `pulumi:"port"`
 	// The contents of an SSH key to use for the connection. This takes preference over the password if provided.
 	PrivateKey pulumi.StringPtrInput `pulumi:"privateKey"`
@@ -172,7 +172,7 @@ func (o ConnectionOutput) PerDialTimeout() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v Connection) *int { return v.PerDialTimeout }).(pulumi.IntPtrOutput)
 }
 
-// The port to connect to.
+// The port to connect to. Defaults to 22.
 func (o ConnectionOutput) Port() pulumi.Float64PtrOutput {
 	return o.ApplyT(func(v Connection) *float64 { return v.Port }).(pulumi.Float64PtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/command/remote/inputs/ConnectionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/command/remote/inputs/ConnectionArgs.java
@@ -100,14 +100,14 @@ public final class ConnectionArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The port to connect to.
+     * The port to connect to. Defaults to 22.
      * 
      */
     @Import(name="port")
     private @Nullable Output<Double> port;
 
     /**
-     * @return The port to connect to.
+     * @return The port to connect to. Defaults to 22.
      * 
      */
     public Optional<Output<Double>> port() {
@@ -313,7 +313,7 @@ public final class ConnectionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param port The port to connect to.
+         * @param port The port to connect to. Defaults to 22.
          * 
          * @return builder
          * 
@@ -324,7 +324,7 @@ public final class ConnectionArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param port The port to connect to.
+         * @param port The port to connect to. Defaults to 22.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/command/remote/outputs/Connection.java
+++ b/sdk/java/src/main/java/com/pulumi/command/remote/outputs/Connection.java
@@ -41,7 +41,7 @@ public final class Connection {
      */
     private @Nullable Integer perDialTimeout;
     /**
-     * @return The port to connect to.
+     * @return The port to connect to. Defaults to 22.
      * 
      */
     private @Nullable Double port;
@@ -103,7 +103,7 @@ public final class Connection {
         return Optional.ofNullable(this.perDialTimeout);
     }
     /**
-     * @return The port to connect to.
+     * @return The port to connect to. Defaults to 22.
      * 
      */
     public Optional<Double> port() {

--- a/sdk/nodejs/remote/copyFile.ts
+++ b/sdk/nodejs/remote/copyFile.ts
@@ -87,6 +87,8 @@ export class CopyFile extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const secretOpts = { additionalSecretOutputs: ["connection"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
+        const replaceOnChanges = { replaceOnChanges: ["triggers[*]"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(CopyFile.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -34,7 +34,7 @@ export namespace remote {
          */
         perDialTimeout?: pulumi.Input<number>;
         /**
-         * The port to connect to.
+         * The port to connect to. Defaults to 22.
          */
         port?: pulumi.Input<number>;
         /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -34,7 +34,7 @@ export namespace remote {
          */
         perDialTimeout?: number;
         /**
-         * The port to connect to.
+         * The port to connect to. Defaults to 22.
          */
         port?: number;
         /**

--- a/sdk/python/pulumi_command/remote/_inputs.py
+++ b/sdk/python/pulumi_command/remote/_inputs.py
@@ -35,7 +35,7 @@ class ConnectionArgs:
         :param pulumi.Input[int] dial_error_limit: Max allowed errors on trying to dial the remote host. -1 set count to unlimited. Default value is 10.
         :param pulumi.Input[str] password: The password we should use for the connection.
         :param pulumi.Input[int] per_dial_timeout: Max number of seconds for each dial attempt. 0 implies no maximum. Default value is 15 seconds.
-        :param pulumi.Input[float] port: The port to connect to.
+        :param pulumi.Input[float] port: The port to connect to. Defaults to 22.
         :param pulumi.Input[str] private_key: The contents of an SSH key to use for the connection. This takes preference over the password if provided.
         :param pulumi.Input[str] private_key_password: The password to use in case the private key is encrypted.
         :param pulumi.Input['ProxyConnectionArgs'] proxy: The connection settings for the bastion/proxy host.
@@ -133,7 +133,7 @@ class ConnectionArgs:
     @pulumi.getter
     def port(self) -> Optional[pulumi.Input[float]]:
         """
-        The port to connect to.
+        The port to connect to. Defaults to 22.
         """
         return pulumi.get(self, "port")
 

--- a/sdk/python/pulumi_command/remote/copy_file.py
+++ b/sdk/python/pulumi_command/remote/copy_file.py
@@ -151,6 +151,8 @@ class CopyFile(pulumi.CustomResource):
             __props__.__dict__["triggers"] = triggers
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["connection"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["triggers[*]"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(CopyFile, __self__).__init__(
             'command:remote:CopyFile',
             resource_name,

--- a/sdk/python/pulumi_command/remote/outputs.py
+++ b/sdk/python/pulumi_command/remote/outputs.py
@@ -64,7 +64,7 @@ class Connection(dict):
         :param int dial_error_limit: Max allowed errors on trying to dial the remote host. -1 set count to unlimited. Default value is 10.
         :param str password: The password we should use for the connection.
         :param int per_dial_timeout: Max number of seconds for each dial attempt. 0 implies no maximum. Default value is 15 seconds.
-        :param float port: The port to connect to.
+        :param float port: The port to connect to. Defaults to 22.
         :param str private_key: The contents of an SSH key to use for the connection. This takes preference over the password if provided.
         :param str private_key_password: The password to use in case the private key is encrypted.
         :param 'ProxyConnection' proxy: The connection settings for the bastion/proxy host.
@@ -142,7 +142,7 @@ class Connection(dict):
     @pulumi.getter
     def port(self) -> Optional[float]:
         """
-        The port to connect to.
+        The port to connect to. Defaults to 22.
         """
         return pulumi.get(self, "port")
 


### PR DESCRIPTION
The struct tag pulumi-go-provider looks for is `provider`, not `providers`.

Also, `replaceOnDelete` is not a thing. Based on the property docs "Trigger replacements on changes to this input" I assume replace on changes is meant. Note that two integration tests already use `Triggers` and pass. I assume this is because a change to `Triggers` causes not a replacement of the resource but a fresh copy?

Plus a bonus docs fix for Connection.Port.