### PR TITLE
Run all unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ provider_debug:
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -gcflags="all=-N -l" -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION_GENERIC}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER))
 
 test_provider: tidy_provider
-	cd provider/tests && go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} ./...
+	cd provider && go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} ./...
 
 dotnet_sdk: sdk/dotnet
 	cd ${PACKDIR}/dotnet/&& \

--- a/provider/pkg/provider/remote/commandController_test.go
+++ b/provider/pkg/provider/remote/commandController_test.go
@@ -45,7 +45,8 @@ func TestOptionalLogging(t *testing.T) {
 		},
 	}
 	go func() {
-		require.NoError(t, server.ListenAndServe())
+		// "ListenAndServe always returns a non-nil error."
+		_ = server.ListenAndServe()
 	}()
 	t.Cleanup(func() {
 		_ = server.Close()

--- a/provider/pkg/provider/util/util.go
+++ b/provider/pkg/provider/util/util.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"sync"
 
+	"github.com/pulumi/pulumi-command/provider/pkg/provider/util/testutil"
+
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 )
@@ -31,16 +33,21 @@ func LogOutput(ctx context.Context, r io.Reader, doneCh chan<- struct{}, severit
 	defer close(doneCh)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
+		msg := scanner.Text()
 		l := p.GetLogger(ctx)
 		switch severity {
 		case diag.Info:
-			l.InfoStatus(scanner.Text())
+			l.InfoStatus(msg)
 		case diag.Warning:
-			l.WarningStatus(scanner.Text())
+			l.WarningStatus(msg)
 		case diag.Error:
-			l.ErrorStatus(scanner.Text())
+			l.ErrorStatus(msg)
 		default:
-			l.DebugStatus(scanner.Text())
+			l.DebugStatus(msg)
+		}
+
+		if testCtx, ok := ctx.(*testutil.TestContext); ok {
+			testCtx.Log(severity, msg)
 		}
 	}
 }


### PR DESCRIPTION
Due to an oversight in how the `test_provider` Make target was written, CI would run only a subset of unit tests.

Fixing this uncovered two test issues that are fixed by the other commits in this PR.
- **Fix test regression in capturing output**
- **Remove erroneous error check in test**
