### PR TITLE
Bump `gradle-nexus.publish-plugin` to 2.0.0

### DIFF
--- a/provider/cmd/pulumi-resource-command/schema.json
+++ b/provider/cmd/pulumi-resource-command/schema.json
@@ -35,7 +35,7 @@
         "com.google.code.gson:gson": "2.8.9",
         "com.pulumi:pulumi": "0.10.0"
       },
-      "gradleNexusPublishPluginVersion": "1.1.0"
+      "gradleNexusPublishPluginVersion": "2.0.0"
     },
     "nodejs": {
       "respectSchemaVersion": true

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -69,7 +69,7 @@ func NewProvider() p.Provider {
 				},
 				"java": map[string]any{
 					"buildFiles":                      "gradle",
-					"gradleNexusPublishPluginVersion": "1.1.0",
+					"gradleNexusPublishPluginVersion": "2.0.0",
 					"dependencies": map[string]any{
 						"com.pulumi:pulumi":               "0.10.0",
 						"com.google.code.gson:gson":       "2.8.9",

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id("signing")
     id("java-library")
     id("maven-publish")
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 group = "com.pulumi"


### PR DESCRIPTION
This is a sanity check to ensure Java publishing still works `io.github.gradle-nexus.publish-plugin` v2.

Refs https://github.com/pulumi/pulumi-java/pull/1479.