### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,4 +229,3 @@ sign-goreleaser-exe-%: bin/jsign-6.0.jar
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 .PHONY: ci-mgmt
-

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ sign-goreleaser-exe-%: bin/jsign-6.0.jar
 			mv $${file}.unsigned $${file}; \
 			az logout; \
 		fi; \
+	fi
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
@@ -228,4 +229,4 @@ sign-goreleaser-exe-%: bin/jsign-6.0.jar
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 .PHONY: ci-mgmt
-	fi
+


### PR DESCRIPTION
I accidentally added the ci-mgmt target before the last line of the sign-goreleaser-exe-% script. Interestingly, this seems to only break the sign-goreleaser-exe-% target so it didn't show up until we attempted to publish!

Fixes: https://github.com/pulumi/pulumi-command/issues/740