### PR TITLE
Feat: Support SSH Agent named pipe on Windows runner

### DIFF
--- a/provider/pkg/provider/remote/connection_unix.go
+++ b/provider/pkg/provider/remote/connection_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package remote
+
+import (
+	"net"
+	"os"
+)
+
+const sshAgentSocketEnvVar = "SSH_AUTH_SOCK"
+
+func tryGetDefaultAgentSocket() *string {
+	if envAgentSocketPath := os.Getenv(sshAgentSocketEnvVar); envAgentSocketPath != "" {
+		return &envAgentSocketPath
+	}
+	return nil
+}
+
+func dialAgent(path string) (net.Conn, error) {
+	return net.Dial("unix", path)
+}

--- a/provider/pkg/provider/remote/connection_windows.go
+++ b/provider/pkg/provider/remote/connection_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package remote
+
+import (
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+const windowsDefaultAgentPipe = `\\.\pipe\openssh-ssh-agent`
+
+func tryGetDefaultAgentSocket() *string {
+	defaultPipe := windowsDefaultAgentPipe
+	timeout := 100 * time.Millisecond
+	// Try to connect with a short timeout to check if the pipe exists
+	if conn, err := winio.DialPipe(defaultPipe, &timeout); err == nil {
+		conn.Close()
+		return &defaultPipe
+	}
+	return nil
+}
+
+func dialAgent(path string) (net.Conn, error) {
+	return winio.DialPipe(path, nil)
+}


### PR DESCRIPTION
Fixes #746 

On Windows, SSH agent use a named pipe, `\\.\pipe\openssh-ssh-agent` by default.
This PR add some code to try to read that named pipe with `winio` when running on a Windows runner