### PR TITLE
Remove a bad comment

### DIFF
--- a/provider/pkg/provider/local/commandController.go
+++ b/provider/pkg/provider/local/commandController.go
@@ -23,11 +23,11 @@ import (
 
 // The following statements are not required. They are type assertions to indicate to Go that Command implements the following interfaces.
 // If the function signature doesn't match or isn't implemented, we get nice compile time errors at this location.
-
-// They would normally be included in the commandController.go file, but they're located here for instructive purposes.
-var _ = (infer.CustomResource[CommandInputs, CommandOutputs])((*Command)(nil))
-var _ = (infer.CustomUpdate[CommandInputs, CommandOutputs])((*Command)(nil))
-var _ = (infer.CustomDelete[CommandOutputs])((*Command)(nil))
+var (
+	_ = (infer.CustomResource[CommandInputs, CommandOutputs])((*Command)(nil))
+	_ = (infer.CustomUpdate[CommandInputs, CommandOutputs])((*Command)(nil))
+	_ = (infer.CustomDelete[CommandOutputs])((*Command)(nil))
+)
 
 // This is the Create method. This will be run on every Command resource creation.
 func (c *Command) Create(ctx context.Context, req infer.CreateRequest[CommandInputs]) (infer.CreateResponse[CommandOutputs], error) {


### PR DESCRIPTION
This comment doesn't make sense in `commandController.go`:

```
// They would normally be included in the commandController.go file, but they're located here for instructive purposes.
```

I moved the type assertions into a block so it's clearer that the comment above them applies to all of them.