### PR TITLE
Collect integration-test coverage and upload to Codecov

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -7,6 +7,7 @@ providerDefaultBranch: main
 parallel: 3
 timeout: 0.0000001
 noSchema: true # Disable schema check.
+integrationTestCoverage: true
 envOverride:
     AWS_REGION: us-west-2
     PULUMI_API: https://api.pulumi-staging.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,11 +313,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -311,6 +311,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -318,6 +320,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -269,11 +269,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -267,6 +267,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -274,6 +276,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -267,6 +267,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -274,6 +276,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,11 +269,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -418,6 +418,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -425,6 +427,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -420,11 +420,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,14 @@ provider:
 provider_debug:
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -gcflags="all=-N -l" -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION_GENERIC}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER))
 
+# Build a coverage-instrumented provider for collecting runtime coverage from
+# integration tests. Set GOCOVERDIR when running the binary (the integration
+# test workflow does this), then convert the resulting data files with
+# `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+.PHONY: provider_cover
+provider_cover:
+	cd provider && go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION_GENERIC}" $(PROJECT)/${PROVIDER_PATH}/cmd/$(PROVIDER)
+
 test_provider: tidy_provider
 	cd provider && $(GO_TEST_EXEC) -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} -coverprofile="coverage.txt" ./...
 
@@ -216,5 +224,5 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+	go run github.com/pulumi/ci-mgmt/provider-ci@21c3957e81a7d182529559ac53417dfc910f8241 generate
 .PHONY: ci-mgmt

--- a/Makefile
+++ b/Makefile
@@ -224,5 +224,5 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@21c3957e81a7d182529559ac53417dfc910f8241 generate
+	go run github.com/pulumi/ci-mgmt/provider-ci@0f6316817af1033e29e83487c523a42b804cdbd3 generate
 .PHONY: ci-mgmt


### PR DESCRIPTION
## Summary

- Adds a `provider_cover` Makefile target that builds the provider with `go build -cover -covermode=atomic`.
- Opts into `integrationTestCoverage` from [pulumi/ci-mgmt#2181](https://github.com/pulumi/ci-mgmt/pull/2181), pinning the \`make ci-mgmt\` reference to that commit.
- Regenerated workflows now: build the provider with `make provider_cover` in the prerequisites job, set `GOCOVERDIR` on each integration test step, convert with `go tool covdata textfmt`, and upload the resulting profile to Codecov under an `integration-<language>` flag.

## Why

Today's Codecov patch coverage only reflects `make test_provider` (Go unit tests). The SDK integration matrix runs the actual provider binary as a subprocess but contributes nothing to coverage, so patches whose new code is exercised end-to-end (e.g. \`CopyToRemote\` CRUD paths, anything driven via \`integration.ProgramTest\`) show artificially low patch coverage on PRs.

Go 1.20+'s \`go build -cover\` lets us instrument the binary directly; setting \`GOCOVERDIR\` collects per-invocation data which we merge with \`go tool covdata\`.

## Caveats

- This depends on pulumi/ci-mgmt#2181 merging first; the \`make ci-mgmt\` target is pinned to that PR's tip commit so the regenerated workflows reflect the new opt-in. Once it merges and is on \`master\`, the pin should be reverted to \`@master\`.
- The opt-in is gated behind the new ci-mgmt config flag, so other native providers are unaffected.

## Test plan

- [x] \`make provider_cover\` builds the binary locally.
- [x] \`make ci-mgmt\` regenerates workflows cleanly against the pinned ci-mgmt commit.
- [ ] Land ci-mgmt#2181, repoint \`make ci-mgmt\` back at \`@master\`, then verify Codecov reports an \`integration-nodejs\` flag with a non-empty profile.