### PR TITLE
Extract repeated string literals into constants for goconst

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -25,6 +25,8 @@ import (
 
 const (
 	Name = "command"
+
+	respectSchemaVersion = "respectSchemaVersion"
 )
 
 // This provider uses the `pulumi-go-provider` library to produce a code-first provider definition.
@@ -49,21 +51,21 @@ func NewProvider() p.Provider {
 			// This contains language specific details for generating the provider's SDKs
 			LanguageMap: map[string]any{
 				"csharp": map[string]any{
-					"respectSchemaVersion": true,
+					respectSchemaVersion: true,
 					"packageReferences": map[string]string{
 						"Pulumi": "3.*",
 					},
 				},
 				"go": map[string]any{
-					"respectSchemaVersion":           true,
+					respectSchemaVersion:             true,
 					"generateResourceContainerTypes": true,
 					"importBasePath":                 "github.com/pulumi/pulumi-command/sdk/go/command",
 				},
 				"nodejs": map[string]any{
-					"respectSchemaVersion": true,
+					respectSchemaVersion: true,
 				},
 				"python": map[string]any{
-					"respectSchemaVersion": true,
+					respectSchemaVersion: true,
 					"pyproject": map[string]bool{
 						"enabled": true,
 					},

--- a/provider/pkg/provider/remote/copyController_test.go
+++ b/provider/pkg/provider/remote/copyController_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
+// Fixture values reused across the copy controller tests.
+const (
+	pathToFile = "path/to/file"
+	aTxtFile   = "a.txt"
+)
+
 // startStaticServer serves the given path→body map over HTTP and returns the base URL. The server
 // is shut down at test end.
 func startStaticServer(t *testing.T, files map[string][]byte) string {
@@ -309,19 +315,19 @@ func TestCheck(t *testing.T) {
 	}
 
 	t.Run("happy path, asset", func(t *testing.T) {
-		news := makeNewInput(&asset.Asset{Path: "path/to/file"}, nil)
+		news := makeNewInput(&asset.Asset{Path: pathToFile}, nil)
 		failures := check(news)
 		assert.Empty(t, failures)
 	})
 
 	t.Run("happy path, archive", func(t *testing.T) {
-		news := makeNewInput(nil, &archive.Archive{Path: "path/to/file"})
+		news := makeNewInput(nil, &archive.Archive{Path: pathToFile})
 		failures := check(news)
 		assert.Empty(t, failures)
 	})
 
 	t.Run("asset or archive, not both", func(t *testing.T) {
-		news := makeNewInput(&asset.Asset{Path: "path/to/file"}, &archive.Archive{Path: "path/to/file"})
+		news := makeNewInput(&asset.Asset{Path: pathToFile}, &archive.Archive{Path: pathToFile})
 		failures := check(news)
 		assert.Len(t, failures, 1)
 	})
@@ -484,7 +490,7 @@ func TestCopyAssetToRemote_RemoteAsset(t *testing.T) {
 
 func TestCopyArchiveToRemote_RemoteArchive(t *testing.T) {
 	zipBytes := makeZipBytes(t, map[string][]byte{
-		"a.txt":     []byte("a"),
+		aTxtFile:    []byte("a"),
 		"sub/b.txt": []byte("b"),
 	})
 	srvURL := startStaticServer(t, map[string][]byte{"/pkgs/bundle.zip": zipBytes})
@@ -549,14 +555,14 @@ func TestCopyArchiveToRemote_AssetArchive(t *testing.T) {
 		require.NoError(t, err)
 
 		arc, err := archive.FromAssets(map[string]any{
-			"a.txt":     fileA,
+			aTxtFile:    fileA,
 			"sub/b.txt": fileB,
 		})
 		require.NoError(t, err)
 
 		require.NoError(t, copyArchiveToRemote(sftpClient, arc, "out"))
 
-		got, err := os.ReadFile(filepath.Join(destDir, "out", "a.txt"))
+		got, err := os.ReadFile(filepath.Join(destDir, "out", aTxtFile))
 		require.NoError(t, err)
 		assert.Equal(t, "alpha", string(got))
 
@@ -574,7 +580,7 @@ func TestCopyArchiveToRemote_AssetArchive(t *testing.T) {
 
 		fileA, err := asset.FromText("alpha")
 		require.NoError(t, err)
-		arc, err := archive.FromAssets(map[string]any{"a.txt": fileA})
+		arc, err := archive.FromAssets(map[string]any{aTxtFile: fileA})
 		require.NoError(t, err)
 
 		err = copyArchiveToRemote(sftpClient, arc, "out")

--- a/provider/tests/provider_test.go
+++ b/provider/tests/provider_test.go
@@ -21,6 +21,19 @@ import (
 	"github.com/pulumi/pulumi-command/provider/pkg/version"
 )
 
+// Property names and fixture values reused across the tests in this package.
+const (
+	createKey                 = "create"
+	environmentKey            = "environment"
+	stderrKey                 = "stderr"
+	stdoutKey                 = "stdout"
+	connectionKey             = "connection"
+	hostKey                   = "host"
+	addPreviousOutputInEnvKey = "addPreviousOutputInEnv"
+	nameEnvVar                = "NAME"
+	testResourceID            = "echo1234"
+)
+
 func provider(t *testing.T) integration.Server {
 	v := semver.MustParse(version.Version)
 	p, err := integration.NewServer(
@@ -60,8 +73,8 @@ func TestLocalCommand(t *testing.T) {
 		resp, err := cmd.Create(p.CreateRequest{
 			Urn: urn,
 			Properties: property.NewMap(map[string]property.Value{
-				"create":      property.New("echo hello, $NAME!"),
-				"environment": env,
+				createKey:      property.New("echo hello, $NAME!"),
+				environmentKey: env,
 			}),
 			DryRun: preview,
 		})
@@ -73,11 +86,11 @@ func TestLocalCommand(t *testing.T) {
 	//
 	// We use this as the final expect for create and the old state during update.
 	createdState := property.NewMap(map[string]property.Value{
-		"create": property.New("echo hello, $NAME!"),
-		"stderr": property.New(""),
-		"stdout": property.New("hello, world!"),
-		"environment": property.New(property.NewMap(map[string]property.Value{
-			"NAME": property.New("world"),
+		createKey: property.New("echo hello, $NAME!"),
+		stderrKey: property.New(""),
+		stdoutKey: property.New("hello, world!"),
+		environmentKey: property.New(property.NewMap(map[string]property.Value{
+			nameEnvVar: property.New("world"),
 		})),
 	})
 
@@ -85,13 +98,13 @@ func TestLocalCommand(t *testing.T) {
 	// the new property map.
 	update := func(preview bool, env property.Value) property.Map {
 		resp, err := cmd.Update(p.UpdateRequest{
-			ID:     "echo1234",
+			ID:     testResourceID,
 			Urn:    urn,
 			DryRun: preview,
 			State:  createdState,
 			Inputs: property.NewMap(map[string]property.Value{
-				"create":      property.New("echo hello, $NAME!"),
-				"environment": env,
+				createKey:      property.New("echo hello, $NAME!"),
+				environmentKey: env,
 			}),
 		})
 		require.NoError(t, err)
@@ -101,10 +114,10 @@ func TestLocalCommand(t *testing.T) {
 	t.Run("create-preview", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"create":      property.New("echo hello, $NAME!"),
-			"stderr":      computed,
-			"stdout":      computed,
-			"environment": unknown,
+			createKey:      property.New("echo hello, $NAME!"),
+			stderrKey:      computed,
+			stdoutKey:      computed,
+			environmentKey: unknown,
 		}),
 			create(true /* preview */, unknown))
 	})
@@ -113,33 +126,33 @@ func TestLocalCommand(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, createdState,
 			create(false /* preview */, property.New(property.NewMap(map[string]property.Value{
-				"NAME": property.New("world"),
+				nameEnvVar: property.New("world"),
 			}))))
 	})
 
 	t.Run("update-preview", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"create":      property.New("echo hello, $NAME!"),
-			"stderr":      computed,
-			"stdout":      computed,
-			"environment": unknown,
+			createKey:      property.New("echo hello, $NAME!"),
+			stderrKey:      computed,
+			stdoutKey:      computed,
+			environmentKey: unknown,
 		}), update(true /* preview */, unknown))
 	})
 	t.Run("update-actual", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"create": property.New("echo hello, $NAME!"),
-			"environment": property.New(property.NewMap(map[string]property.Value{
-				"NAME": property.New("Pulumi"),
+			createKey: property.New("echo hello, $NAME!"),
+			environmentKey: property.New(property.NewMap(map[string]property.Value{
+				nameEnvVar: property.New("Pulumi"),
 			})),
 
-			"stderr": property.New(""),
-			"stdout": property.New("hello, Pulumi!"),
+			stderrKey: property.New(""),
+			stdoutKey: property.New("hello, Pulumi!"),
 		}),
 
 			update(false /* preview */, property.New(property.NewMap(map[string]property.Value{
-				"NAME": property.New("Pulumi"),
+				nameEnvVar: property.New("Pulumi"),
 			}))))
 	})
 }
@@ -154,26 +167,26 @@ func TestLocalCommandStdoutStderrFlag(t *testing.T) {
 		resp, err := cmd.Create(p.CreateRequest{
 			Urn: urn,
 			Properties: property.NewMap(map[string]property.Value{
-				"create": property.New("echo std, $PULUMI_COMMAND_STDOUT"),
+				createKey: property.New("echo std, $PULUMI_COMMAND_STDOUT"),
 			}),
 		})
 		require.NoError(t, err)
 		return resp.Properties
 	}
 	createdState := property.NewMap(map[string]property.Value{
-		"create": property.New("echo std, $PULUMI_COMMAND_STDOUT"),
-		"stderr": property.New(""),
-		"stdout": property.New("std,"),
+		createKey: property.New("echo std, $PULUMI_COMMAND_STDOUT"),
+		stderrKey: property.New(""),
+		stdoutKey: property.New("std,"),
 	})
 
 	update := func(addPreviousOutputInEnv bool) property.Map {
 		resp, err := cmd.Update(p.UpdateRequest{
-			ID:    "echo1234",
+			ID:    testResourceID,
 			Urn:   urn,
 			State: createdState,
 			Inputs: property.NewMap(map[string]property.Value{
-				"create":                 property.New("echo std, $PULUMI_COMMAND_STDOUT"),
-				"addPreviousOutputInEnv": property.New(addPreviousOutputInEnv),
+				createKey:                 property.New("echo std, $PULUMI_COMMAND_STDOUT"),
+				addPreviousOutputInEnvKey: property.New(addPreviousOutputInEnv),
 			}),
 		})
 		require.NoError(t, err)
@@ -187,10 +200,10 @@ func TestLocalCommandStdoutStderrFlag(t *testing.T) {
 
 	t.Run("update-actual-with-std", func(t *testing.T) {
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"create":                 property.New("echo std, $PULUMI_COMMAND_STDOUT"),
-			"stderr":                 property.New(""),
-			"stdout":                 property.New("std, std,"),
-			"addPreviousOutputInEnv": property.New(true),
+			createKey:                 property.New("echo std, $PULUMI_COMMAND_STDOUT"),
+			stderrKey:                 property.New(""),
+			stdoutKey:                 property.New("std, std,"),
+			addPreviousOutputInEnvKey: property.New(true),
 		}),
 
 			update(true))
@@ -198,10 +211,10 @@ func TestLocalCommandStdoutStderrFlag(t *testing.T) {
 
 	t.Run("update-actual-without-std", func(t *testing.T) {
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"create":                 property.New("echo std, $PULUMI_COMMAND_STDOUT"),
-			"stderr":                 property.New(""),
-			"stdout":                 property.New("std,"),
-			"addPreviousOutputInEnv": property.New(false),
+			createKey:                 property.New("echo std, $PULUMI_COMMAND_STDOUT"),
+			stderrKey:                 property.New(""),
+			stdoutKey:                 property.New("std,"),
+			addPreviousOutputInEnvKey: property.New(false),
 		}),
 
 			update(false))
@@ -216,15 +229,15 @@ func TestRemoteCommand(t *testing.T) {
 			Urn:    urn("remote", "Command", "check"),
 			DryRun: true,
 			Properties: property.NewMap(map[string]property.Value{
-				"create": property.New("<create command>"),
-				"connection": property.New(property.NewMap(map[string]property.Value{
-					"host": property.New("<host port>"),
+				createKey: property.New("<create command>"),
+				connectionKey: property.New(property.NewMap(map[string]property.Value{
+					hostKey: property.New("<host port>"),
 				})).WithSecret(true),
 			}),
 		})
 		require.NoError(t, err)
 
-		for _, key := range []string{"stdout", "stderr"} {
+		for _, key := range []string{stdoutKey, stderrKey} {
 			p := resp.Properties.Get(key)
 			assert.True(t, p.HasComputed())
 			assert.False(t, p.HasSecrets())
@@ -260,7 +273,7 @@ func TestRemoteCommandStdoutStderrFlag(t *testing.T) {
 
 	// Run a create against an in-memory provider, assert it succeeded, and return the created property map.
 	connection := property.New(property.NewMap(map[string]property.Value{
-		"host":           property.New(sshServer.Host),
+		hostKey:          property.New(sshServer.Host),
 		"port":           property.New(float64(sshServer.Port)),
 		"user":           property.New("arbitrary-user"), // unused but prevents nil panic
 		"perDialTimeout": property.New(1.0),
@@ -272,20 +285,20 @@ func TestRemoteCommandStdoutStderrFlag(t *testing.T) {
 	//
 	// We use this as the final expect for create and the old state during update.
 	initialState := property.NewMap(map[string]property.Value{
-		"connection":             connection,
-		"create":                 property.New(createCommand),
-		"stderr":                 property.New(""),
-		"stdout":                 property.New("Response{}"),
-		"addPreviousOutputInEnv": property.New(true),
+		connectionKey:             connection,
+		createKey:                 property.New(createCommand),
+		stderrKey:                 property.New(""),
+		stdoutKey:                 property.New("Response{}"),
+		addPreviousOutputInEnvKey: property.New(true),
 	})
 
-	t.Run("create", func(t *testing.T) {
+	t.Run(createKey, func(t *testing.T) {
 		createResponse, err := cmd.Create(p.CreateRequest{
 			Urn: urn,
 			Properties: property.NewMap(map[string]property.Value{
-				"connection":             connection,
-				"create":                 property.New(createCommand),
-				"addPreviousOutputInEnv": property.New(true),
+				connectionKey:             connection,
+				createKey:                 property.New(createCommand),
+				addPreviousOutputInEnvKey: property.New(true),
 			}),
 		})
 		require.NoError(t, err)
@@ -296,13 +309,13 @@ func TestRemoteCommandStdoutStderrFlag(t *testing.T) {
 	// the new property map.
 	update := func(addPreviousOutputInEnv bool) property.Map {
 		resp, err := cmd.Update(p.UpdateRequest{
-			ID:    "echo1234",
+			ID:    testResourceID,
 			Urn:   urn,
 			State: initialState,
 			Inputs: property.NewMap(map[string]property.Value{
-				"connection":             connection,
-				"create":                 property.New(createCommand),
-				"addPreviousOutputInEnv": property.New(addPreviousOutputInEnv),
+				connectionKey:             connection,
+				createKey:                 property.New(createCommand),
+				addPreviousOutputInEnvKey: property.New(addPreviousOutputInEnv),
 			}),
 		})
 		require.NoError(t, err)
@@ -311,12 +324,12 @@ func TestRemoteCommandStdoutStderrFlag(t *testing.T) {
 
 	t.Run("update-actual-with-std", func(t *testing.T) {
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"connection": connection,
-			"create":     property.New(createCommand),
-			"stderr":     property.New(""),
+			connectionKey: connection,
+			createKey:     property.New(createCommand),
+			stderrKey:     property.New(""),
 			// Running with addPreviousOutputInEnv=true sets the environment variable:
-			"stdout":                 property.New("Response{PULUMI_COMMAND_STDOUT=Response{}}"),
-			"addPreviousOutputInEnv": property.New(true),
+			stdoutKey:                 property.New("Response{PULUMI_COMMAND_STDOUT=Response{}}"),
+			addPreviousOutputInEnvKey: property.New(true),
 		}),
 
 			update(true))
@@ -324,12 +337,12 @@ func TestRemoteCommandStdoutStderrFlag(t *testing.T) {
 
 	t.Run("update-actual-without-std", func(t *testing.T) {
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"connection": connection,
-			"create":     property.New(createCommand),
-			"stderr":     property.New(""),
+			connectionKey: connection,
+			createKey:     property.New(createCommand),
+			stderrKey:     property.New(""),
 			// Running without addPreviousOutputInEnv does not set the environment variable:
-			"stdout":                 property.New("Response{}"),
-			"addPreviousOutputInEnv": property.New(false),
+			stdoutKey:                 property.New("Response{}"),
+			addPreviousOutputInEnvKey: property.New(false),
 		}),
 
 			update(false))
@@ -344,18 +357,18 @@ func TestRegress248(t *testing.T) {
 	resp, err := provider(t).Check(p.CheckRequest{
 		Urn: urn("remote", "Command", "check"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"create": property.New("<create command>"),
-			"connection": property.New(property.NewMap(map[string]property.Value{
-				"host": property.New("<required value>"),
+			createKey: property.New("<create command>"),
+			connectionKey: property.New(property.NewMap(map[string]property.Value{
+				hostKey: property.New("<required value>"),
 			})),
 		}),
 	})
 	require.NoError(t, err)
 	assert.Empty(t, resp.Failures)
 	assert.Equal(t, property.NewMap(map[string]property.Value{
-		"create": property.New("<create command>"),
-		"connection": property.New(property.NewMap(map[string]property.Value{
-			"host":           property.New("<required value>"),
+		createKey: property.New("<create command>"),
+		connectionKey: property.New(property.NewMap(map[string]property.Value{
+			hostKey:          property.New("<required value>"),
 			"port":           property.New(22.0),
 			"user":           property.New("root"),
 			"dialErrorLimit": property.New(10.0),
@@ -378,7 +391,7 @@ func TestLocalRun(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, property.NewMap(map[string]property.Value{
 		"command": property.New(`echo "Hello, World!"`),
-		"stderr":  property.New(""),
-		"stdout":  property.New("Hello, World!"),
+		stderrKey: property.New(""),
+		stdoutKey: property.New("Hello, World!"),
 	}), resp.Return)
 }


### PR DESCRIPTION
The ci-mgmt workflow update bumps golangci-lint to 2.12.2, which enables stricter `goconst` checks. This hoists repeated string literals across three packages into named constants. Verified locally with golangci-lint 2.12.2 (`--build-tags=all`) reporting 0 issues.

Part of #1320
Part of pulumi/home#4817
